### PR TITLE
manufacture grammar fix

### DIFF
--- a/schema/bom-1.3-SNAPSHOT.schema.json
+++ b/schema/bom-1.3-SNAPSHOT.schema.json
@@ -114,7 +114,7 @@
         },
         "supplier": {
           "title": "Supplier",
-          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacture, but may also be a distributor or repackager.",
+          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
           "$ref": "#/definitions/organizationalEntity"
         }
       }
@@ -257,7 +257,7 @@
         },
         "supplier": {
           "title": "Component Supplier",
-          "description": " The organization that supplied the component. The supplier may often be the manufacture, but may also be a distributor or repackager.",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "author": {

--- a/schema/bom-1.3-SNAPSHOT.xsd
+++ b/schema/bom-1.3-SNAPSHOT.xsd
@@ -79,7 +79,7 @@ limitations under the License.
             <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>The organization that supplied the component that the BOM describes. The
-                        supplier may often be the manufacture, but may also be a distributor or repackager.</xs:documentation>
+                        supplier may often be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
@@ -231,7 +231,7 @@ limitations under the License.
             <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>The organization that supplied the component. The supplier may often
-                        be the manufacture, but may also be a distributor or repackager.</xs:documentation>
+                        be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="author" type="xs:normalizedString" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
Follow-on from #57, which on balance seems like a bad idea.

This just fixes the descriptive text part for 1.3 schemas, which should be a compatible change.