### PR TITLE
Refactor BOM license to make use of license choice type

### DIFF
--- a/schema/bom-1.3-SNAPSHOT.schema.json
+++ b/schema/bom-1.3-SNAPSHOT.schema.json
@@ -128,30 +128,7 @@
         "licenses": {
           "type": "array",
           "title": "BOM License(s)",
-          "items": {
-            "properties": {
-              "license": {
-                "$ref": "#/definitions/license"
-              },
-              "expression": {
-                "type": "string",
-                "title": "SPDX License Expression",
-                "examples": [
-                  "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-                  "GPL-3.0-only WITH Classpath-exception-2.0"
-                ],
-                "pattern": "^(.*)$"
-              }
-            },
-            "oneOf":[
-              {
-                "required": ["license"]
-              },
-              {
-                "required": ["expression"]
-              }
-            ]
-          }
+          "items": {"$ref": "#/definitions/licenseChoice"}
         },
         "properties": {
           "type": "array",

--- a/schema/bom-1.3-SNAPSHOT.xsd
+++ b/schema/bom-1.3-SNAPSHOT.xsd
@@ -79,22 +79,7 @@ limitations under the License.
                         supplier may often be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="licenses" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>Licenses for the BOM document.</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:choice>
-                        <xs:element name="license" type="bom:licenseType" minOccurs="0" maxOccurs="unbounded"/>
-                        <xs:element name="expression" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation>A valid SPDX license expression.
-                                    Refer to https://spdx.org/specifications for syntax requirements</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:choice>
-                </xs:complexType>
-            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Provides the ability to document properties in a key/value store.


### PR DESCRIPTION
Should not be any material change. Just removing duplicate definitions.