### PR TITLE
spec1.4 JSON fixes #83

### DIFF
--- a/schema/bom-1.4-SNAPSHOT.schema.json
+++ b/schema/bom-1.4-SNAPSHOT.schema.json
@@ -181,7 +181,6 @@
           "description": "The version of the tool"
         },
         "hashes": {
-          "$id": "#/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -427,11 +426,7 @@
           "title": "External References"
         },
         "components": {
-          "$id": "#/properties/components",
-          "type": "array",
-          "items": {"$ref": "#/definitions/component"},
-          "uniqueItems": true,
-          "title": "Components"
+          "$ref": "#/properties/components"
         },
         "evidence": {
           "$ref": "#/definitions/componentEvidence",
@@ -864,7 +859,6 @@
           ]
         },
         "hashes": {
-          "$id": "#/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -975,11 +969,7 @@
           "title": "External References"
         },
         "services": {
-          "$id": "#/properties/services",
-          "type": "array",
-          "items": {"$ref": "#/definitions/service"},
-          "uniqueItems": true,
-          "title": "Services"
+          "$ref": "#/properties/services"
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",

--- a/schema/bom-1.4-SNAPSHOT.schema.json
+++ b/schema/bom-1.4-SNAPSHOT.schema.json
@@ -18,7 +18,6 @@
       ]
     },
     "bomFormat": {
-      "$id": "#/properties/bomFormat",
       "type": "string",
       "title": "BOM Format",
       "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention nor does JSON schema support namespaces.",
@@ -27,14 +26,12 @@
       ]
     },
     "specVersion": {
-      "$id": "#/properties/specVersion",
       "type": "string",
       "title": "CycloneDX Specification Version",
       "description": "The version of the CycloneDX specification a BOM is written to (starting at version 1.2)",
       "examples": ["1.4"]
     },
     "serialNumber": {
-      "$id": "#/properties/serialNumber",
       "type": "string",
       "title": "BOM Serial Number",
       "description": "Every BOM generated should have a unique serial number, even if the contents of the BOM being generated have not changed over time. The process or tool responsible for creating the BOM should create random UUID's for every BOM generated.",
@@ -42,7 +39,6 @@
       "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
     },
     "version": {
-      "$id": "#/properties/version",
       "type": "integer",
       "title": "BOM Version",
       "description": "The version allows component publishers/authors to make changes to existing BOMs to update various aspects of the document such as description or licenses. When a system is presented with multiple BOMs for the same component, the system should use the most recent version of the BOM. The default version is '1' and should be incremented for each version of the BOM that is published. Each version of a component should have a unique BOM and if no changes are made to the BOMs, then each BOM will have a version of '1'.",
@@ -50,34 +46,29 @@
       "examples": [1]
     },
     "metadata": {
-      "$id": "#/properties/metadata",
       "$ref": "#/definitions/metadata",
       "title": "BOM Metadata",
       "description": "Provides additional information about a BOM."
     },
     "components": {
-      "$id": "#/properties/components",
       "type": "array",
       "items": {"$ref": "#/definitions/component"},
       "uniqueItems": true,
       "title": "Components"
     },
     "services": {
-      "$id": "#/properties/services",
       "type": "array",
       "items": {"$ref": "#/definitions/service"},
       "uniqueItems": true,
       "title": "Services"
     },
     "externalReferences": {
-      "$id": "#/properties/externalReferences",
       "type": "array",
       "items": {"$ref": "#/definitions/externalReference"},
       "title": "External References",
       "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
     },
     "dependencies": {
-      "$id": "#/properties/dependencies",
       "type": "array",
       "items": {"$ref": "#/definitions/dependency"},
       "uniqueItems": true,
@@ -85,7 +76,6 @@
       "description": "Provides the ability to document dependency relationships."
     },
     "compositions": {
-      "$id": "#/properties/compositions",
       "type": "array",
       "items": {"$ref": "#/definitions/compositions"},
       "uniqueItems": true,


### PR DESCRIPTION
part of #83 for spec 1.4 

* removed duplicate `$id` definitions
* removed all `$id` markers (the ones that were just json-pointers prefixed with `#` and all the others that were not used internally)