### PR TITLE
add GH-workflow: php ci

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,28 @@
+# docs: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: PHP CI
+
+on: [push, pull_request, workflow_dispatch]
+
+defaults:
+  run:
+    working-directory: tools/src/test/php
+
+jobs:
+  test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        # see https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: composer:v2
+      - name: Install Depenencies
+        run: composer install
+      - name: Run test
+        run: composer run test

--- a/tools/src/test/php/README.md
+++ b/tools/src/test/php/README.md
@@ -5,7 +5,7 @@ for validation of a schema
 
 ## requirements
 
-* `php:^7.4`
+* php >= 7.4
 * php composer
 
 ## setup

--- a/tools/src/test/php/composer.json
+++ b/tools/src/test/php/composer.json
@@ -1,16 +1,21 @@
 {
   "minimum-stability": "stable",
   "require": {
-    "php": "^7.4|^8.0",
-    "opis/json-schema": "^2.2"
+    "php": "^7.4 || ^8.0",
+    "ext-json": "*",
+    "opis/json-schema": "2.3"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest"
   },
   "scripts": {
-    "test": "@php -f json-schema-lint-tests.php"
+    "test": [
+      "@test:json-schema-lint"
+    ],
+    "test:json-schema-lint": "@php -f json-schema-lint-tests.php --"
   },
   "scripts-descriptions": {
-    "test": "run tests"
+    "test": "run all tests",
+    "test:json-schema-lint": "lint JSON schema."
   }
 }


### PR DESCRIPTION
part of #86 for #123

* added the existing php tests as a GitHub workflow
* slight fixes and extensibility-modifications to existing php test-setup

:point_up:  PHP CI is currently failing, since some JSON schema files are not entirely valid/plausible - which is topic of #83/#123
this might be fixed via (#84/#125/...) - #124
as soon as the JSON schema files were fixed, they will pass.
Then these test can act as a gatekeeper.