### PR TITLE
spec 1.4 JSON schema: remove unnecessary self-shadowing `$id`

### DIFF
--- a/schema/bom-1.4-SNAPSHOT.schema.json
+++ b/schema/bom-1.4-SNAPSHOT.schema.json
@@ -83,7 +83,6 @@
       "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
     },
     "vulnerabilities": {
-      "$id": "#/properties/vulnerabilities",
       "type": "array",
       "items": {"$ref": "#/definitions/vulnerability"},
       "uniqueItems": true,
@@ -91,7 +90,6 @@
       "description": "Vulnerabilities identified in components or services."
     },
     "signature": {
-      "$id": "#/properties/signature",
       "$ref": "#/definitions/signature",
       "title": "Signature",
       "description": "Enveloped signature in JSON Signature Format (JSF)."


### PR DESCRIPTION
part of #83 