### PR TITLE
Add service release notes to v1.4 proto file

### DIFF
--- a/schema/bom-1.4-SNAPSHOT.proto
+++ b/schema/bom-1.4-SNAPSHOT.proto
@@ -385,6 +385,8 @@ message Service {
   repeated Service services = 13;
   // Specifies optional, custom, properties
   repeated Property properties = 14;
+  // Specifies optional release notes.
+  optional ReleaseNotes releaseNotes = 15;
 }
 
 message Swid {


### PR DESCRIPTION
This was missing from the proto file, but is present in JSON and XML schemas.