### PR TITLE
Preserve  keys, but fix potential JSON pointers to reflect actual DOM…

### DIFF
--- a/schema/bom-1.2-strict.schema.json
+++ b/schema/bom-1.2-strict.schema.json
@@ -152,7 +152,7 @@
           "description": "The date and time (timestamp) when the document was created."
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/tool/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -446,7 +446,7 @@
           "title": "External References"
         },
         "components": {
-          "$id": "#/properties/components",
+          "$id": "#/definitions/component/properties/components",
           "type": "array",
           "items": {"$ref": "#/definitions/component"},
           "uniqueItems": true,
@@ -985,7 +985,7 @@
           "title": "External References"
         },
         "services": {
-          "$id": "#/properties/services",
+          "$id": "#/definitions/service/properties/services",
           "type": "array",
           "items": {"$ref": "#/definitions/service"},
           "uniqueItems": true,

--- a/schema/bom-1.2.schema.json
+++ b/schema/bom-1.2.schema.json
@@ -143,7 +143,7 @@
           "description": "The date and time (timestamp) when the document was created."
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/tool/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -432,7 +432,7 @@
           "title": "External References"
         },
         "components": {
-          "$id": "#/properties/components",
+          "$id": "#/definitions/component/properties/components",
           "type": "array",
           "items": {"$ref": "#/definitions/component"},
           "uniqueItems": true,
@@ -957,7 +957,7 @@
           "title": "External References"
         },
         "services": {
-          "$id": "#/properties/services",
+          "$id": "#/definitions/service/properties/services",
           "type": "array",
           "items": {"$ref": "#/definitions/service"},
           "uniqueItems": true,

--- a/schema/bom-1.3-strict.schema.json
+++ b/schema/bom-1.3-strict.schema.json
@@ -167,7 +167,7 @@
           "description": "The date and time (timestamp) when the document was created."
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/tool/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -408,7 +408,7 @@
           "title": "External References"
         },
         "components": {
-          "$id": "#/properties/components",
+          "$id": "#/definitions/component/properties/components",
           "type": "array",
           "items": {"$ref": "#/definitions/component"},
           "uniqueItems": true,
@@ -834,7 +834,7 @@
           ]
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/externalReference/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -945,7 +945,7 @@
           "title": "External References"
         },
         "services": {
-          "$id": "#/properties/services",
+          "$id": "#/definitions/service/properties/services",
           "type": "array",
           "items": {"$ref": "#/definitions/service"},
           "uniqueItems": true,

--- a/schema/bom-1.3.schema.json
+++ b/schema/bom-1.3.schema.json
@@ -158,7 +158,7 @@
           "description": "The date and time (timestamp) when the document was created."
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/tool/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -395,7 +395,7 @@
           "title": "External References"
         },
         "components": {
-          "$id": "#/properties/components",
+          "$id": "#/definitions/component/properties/components",
           "type": "array",
           "items": {"$ref": "#/definitions/component"},
           "uniqueItems": true,
@@ -809,7 +809,7 @@
           ]
         },
         "hashes": {
-          "$id": "#/properties/hashes",
+          "$id": "#/definitions/externalReference/properties/hashes",
           "type": "array",
           "items": {"$ref": "#/definitions/hash"},
           "title": "Hashes",
@@ -918,7 +918,7 @@
           "title": "External References"
         },
         "services": {
-          "$id": "#/properties/services",
+          "$id": "#/definitions/service/properties/services",
           "type": "array",
           "items": {"$ref": "#/definitions/service"},
           "uniqueItems": true,


### PR DESCRIPTION
This PR seeks to suggest what could be least-invasive fix for the duplicate `$id` issue as described in https://github.com/CycloneDX/specification/issues/123.

It preserves all $id tags in case they were being used to reference schema objects from external schemas, but simply fixes those `$id` whose value (URI fragments), if used as JSON pointers (into the JSON schema document) did not match the actual object hierarchy of the actual document object model (DOM).