### PR TITLE
Fix invalid ref in tools/src/test/resources/1.4/valid-vulnerability-1.4.json

### DIFF
--- a/tools/src/test/resources/1.4/valid-vulnerability-1.4.json
+++ b/tools/src/test/resources/1.4/valid-vulnerability-1.4.json
@@ -39,7 +39,7 @@
           "score": 9.8,
           "severity": "critical",
           "method": "CVSSv3",
-          "vector": "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
           "justification": "An optional reason for rating the vulnerability as it was"
         }
       ],

--- a/tools/src/test/resources/1.4/valid-vulnerability-1.4.json
+++ b/tools/src/test/resources/1.4/valid-vulnerability-1.4.json
@@ -100,7 +100,7 @@
       },
       "affects": [
         {
-          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.9",
+          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
           "versions": [
             {
               "range": "vers:semver/<2.6.7.5",


### PR DESCRIPTION
1. The vulnerability use a reference to a component that is not in the BOM.
Should be `pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4`
instead of `pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.9`
Because the firs tone is in the bom-ref of a component in the BOM.

See [tools/src/test/resources/1.4/valid-vulnerability-1.4.json](../blob/master/tools/src/test/resources/1.4/valid-vulnerability-1.4.json#L103)

2. the CVSS v3 vector is wrong (not well formed data)

It is `"vector": "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",` in the current file.
Should be `"vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",`