### PR TITLE
fix json-schema-file strict schema property

### DIFF
--- a/schema/bom-1.2-strict.schema.json
+++ b/schema/bom-1.2-strict.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.2b.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "$id": "#/properties/bomFormat",

--- a/schema/bom-1.2-strict.schema.json
+++ b/schema/bom-1.2-strict.schema.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "enum": [
-        "http://cyclonedx.org/schema/bom-1.2a.schema.json"
+        "http://cyclonedx.org/schema/bom-1.2b.schema.json"
       ]
     },
     "bomFormat": {

--- a/schema/bom-1.3-strict.schema.json
+++ b/schema/bom-1.3-strict.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.3a.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "$id": "#/properties/bomFormat",

--- a/schema/bom-1.3-strict.schema.json
+++ b/schema/bom-1.3-strict.schema.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "enum": [
-        "http://cyclonedx.org/schema/bom-1.3.schema.json"
+        "http://cyclonedx.org/schema/bom-1.3a.schema.json"
       ]
     },
     "bomFormat": {

--- a/schema/bom-1.4.schema.json
+++ b/schema/bom-1.4.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.4.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "type": "string",

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -11,10 +11,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.5.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "type": "string",


### PR DESCRIPTION
Hello @stevespringett ,

looks like there is a bug in the strict schema files:  the optional `bom.$schema` property was not updated, when the actual schema `$id` revision was bumped.

to mitigate this for now and the future, i propose to lax the definition - from a specific string to any string.
This means: no need to modify the schema version on multiple places, when bumping.