### PR TITLE
fix: align XML schema with JSON schema for `Dependency` type #146

### DIFF
--- a/schema/bom-1.4.xsd
+++ b/schema/bom-1.4.xsd
@@ -22,7 +22,7 @@ limitations under the License.
            targetNamespace="http://cyclonedx.org/schema/bom/1.4"
            vc:minVersion="1.0"
            vc:maxVersion="1.1"
-           version="1.4.2">
+           version="1.4.3">
 
     <xs:import namespace="http://cyclonedx.org/schema/spdx" schemaLocation="http://cyclonedx.org/schema/spdx"/>
 
@@ -1186,11 +1186,11 @@ limitations under the License.
 
     <xs:complexType name="dependencyType">
         <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="dependency" type="bom:dependencyType"/>
+            <xs:element name="dependency" type="bom:refType"/>
         </xs:sequence>
         <xs:attribute name="ref" type="bom:refType" use="required">
             <xs:annotation>
-                <xs:documentation>References a component or service by the its bom-ref attribute</xs:documentation>
+                <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:anyAttribute namespace="##other" processContents="lax">


### PR DESCRIPTION
Update XML schema to align with JSON schema for `dependency` type as per #146.

Signed-off-by: Paul Horton <paul.horton@owasp.org>