### PR TITLE
Added firstIssued and lastUpdated timestamps to vulnerability analysis

### DIFF
--- a/schema/bom-1.5.proto
+++ b/schema/bom-1.5.proto
@@ -600,6 +600,10 @@ message VulnerabilityAnalysis {
   repeated VulnerabilityResponse response = 3;
   // Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability.
   optional string detail = 4;
+  // The date and time (timestamp) when the analysis was first issued.
+  optional google.protobuf.Timestamp firstIssued = 5;
+  // The date and time (timestamp) when the analysis was last updated.
+  optional google.protobuf.Timestamp lastUpdated = 6;
 }
 
 enum ImpactAnalysisState {

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -1601,6 +1601,18 @@
               "type": "string",
               "title": "Detail",
               "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            },
+            "firstIssued": {
+              "type": "string",
+              "format": "date-time",
+              "title": "First Issued",
+              "description": "The date and time (timestamp) when the analysis was first issued."
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Updated",
+              "description": "The date and time (timestamp) when the analysis was last updated."
             }
           }
         },

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -1957,6 +1957,20 @@ limitations under the License.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
+                        <xs:element name="firstIssued" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was first issued.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was last updated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/tools/src/test/resources/1.5/valid-vulnerability-1.5.json
+++ b/tools/src/test/resources/1.5/valid-vulnerability-1.5.json
@@ -96,7 +96,9 @@
         "state": "not_affected",
         "justification": "code_not_reachable",
         "response": ["will_not_fix", "update"],
-        "detail": "An optional explanation of why the application is not affected by the vulnerable component."
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component.",
+        "firstIssued": "2022-01-01T00:00:00.000Z",
+        "lastUpdated": "2022-02-01T00:00:00.000Z"
       },
       "affects": [
         {

--- a/tools/src/test/resources/1.5/valid-vulnerability-1.5.textproto
+++ b/tools/src/test/resources/1.5/valid-vulnerability-1.5.textproto
@@ -84,6 +84,14 @@ vulnerabilities {
     response: VULNERABILITY_RESPONSE_WILL_NOT_FIX
     response: VULNERABILITY_RESPONSE_UPDATE
     detail: "An optional explanation of why the application is not affected by the vulnerable component."
+    firstIssued: {
+      seconds: 1641042000
+      nanos: 3
+    }
+    lastUpdated: {
+      seconds: 1643720400
+      nanos: 3
+    }
   }
   affects: {
     ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"

--- a/tools/src/test/resources/1.5/valid-vulnerability-1.5.xml
+++ b/tools/src/test/resources/1.5/valid-vulnerability-1.5.xml
@@ -96,6 +96,8 @@
                     <response>update</response>
                 </responses>
                 <detail>An optional explanation of why the application is not affected by the vulnerable component.</detail>
+                <firstIssued>2022-01-01T00:00:00.000Z</firstIssued>
+                <lastUpdated>2022-02-01T00:00:00.000Z</lastUpdated>
             </analysis>
             <affects>
                 <target>


### PR DESCRIPTION
Closes #142 and implements 0.9 draft of CISA VEX requirements

Signed-off-by: Steve Springett <steve@springett.us>