### PR TITLE
fix: XML schema 1.4 make all `ref` arguments `type="bom:refType"`

### DIFF
--- a/schema/bom-1.4.xsd
+++ b/schema/bom-1.4.xsd
@@ -1969,7 +1969,7 @@ limitations under the License.
                         <xs:element name="target">
                             <xs:complexType>
                                 <xs:sequence minOccurs="0" maxOccurs="1">
-                                    <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                                    <xs:element name="ref" type="bom:refType" minOccurs="1" maxOccurs="1">
                                         <xs:annotation>
                                             <xs:documentation>References a component or service by the objects bom-ref.</xs:documentation>
                                         </xs:annotation>


### PR DESCRIPTION
fixes #182

The `bom:refType` is just an alias of `xs:string` with an annotation.
Therefore, I propose to merge this without any version bump.