### PR TITLE
fix `vulnerability.affects[].versions[].range` ref

### DIFF
--- a/schema/bom-1.4.schema.json
+++ b/schema/bom-1.4.schema.json
@@ -1641,7 +1641,7 @@
                     },
                     "range": {
                       "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
-                      "$ref": "#/definitions/version"
+                      "$ref": "#/definitions/range"
                     },
                     "status": {
                       "description": "The vulnerability status for the version or range of versions.",


### PR DESCRIPTION
i found `vulnerability.affects[].versions[].range` wrong. it pointed to `version`, not `range`.

this is to be considered a non-braking change.
actually it does not affect any documents, since the old ref and the fixed ref point to equal data structures.
