### PR TITLE
Fixing missing data governance on service data

### DIFF
--- a/schema/bom-1.5.proto
+++ b/schema/bom-1.5.proto
@@ -147,6 +147,8 @@ message DataFlow {
   repeated string source = 5;
   // The URI, URL, or BOM-Link of the components or services the data is sent to
   repeated string destination = 6;
+  // Data Governance
+  optional DataGovernance governance = 7;
 }
 
 // Specifies the flow direction of the data. Valid values are: inbound, outbound, bi-directional, and unknown. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known.
@@ -1109,20 +1111,20 @@ message ComponentData {
     // Provides the ability to document name-value parameters used for configuration.
     repeated Property properties = 3;
   }
+}
 
-  message DataGovernance {
-    // Data custodians are responsible for the safe custody, transport, and storage of data.
-    repeated DataGovernanceResponsibleParty custodians = 1;
-    // Data stewards are responsible for data content, context, and associated business rules.
-    repeated DataGovernanceResponsibleParty stewards = 2;
-    // Data owners are concerned with risk and appropriate access to data.
-    repeated DataGovernanceResponsibleParty owners = 3;
+message DataGovernance {
+  // Data custodians are responsible for the safe custody, transport, and storage of data.
+  repeated DataGovernanceResponsibleParty custodians = 1;
+  // Data stewards are responsible for data content, context, and associated business rules.
+  repeated DataGovernanceResponsibleParty stewards = 2;
+  // Data owners are concerned with risk and appropriate access to data.
+  repeated DataGovernanceResponsibleParty owners = 3;
 
-    message DataGovernanceResponsibleParty {
-      oneof choice {
-        OrganizationalEntity organization = 1;
-        OrganizationalContact contact = 2;
-      }
+  message DataGovernanceResponsibleParty {
+    oneof choice {
+      OrganizationalEntity organization = 1;
+      OrganizationalContact contact = 2;
     }
   }
 }

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -1313,6 +1313,11 @@
             "Credit card information being exchanged in between the web app and the database"
           ]
         },
+        "governance": {
+          "type": "object",
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        },
         "source": {
           "type": "array",
           "items": {
@@ -2548,28 +2553,32 @@
         "governance": {
           "type": "object",
           "title": "Data Governance",
-          "description": "",
-          "additionalProperties": false,
-          "properties": {
-            "custodians": {
-              "type": "array",
-              "title": "Data Custodians",
-              "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
-              "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
-            },
-            "stewards": {
-              "type": "array",
-              "title": "Data Stewards",
-              "description": "Data stewards are responsible for data content, context, and associated business rules.",
-              "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
-            },
-            "owners": {
-              "type": "array",
-              "title": "Data Owners",
-              "description": "Data owners are concerned with risk and appropriate access to data.",
-              "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
-            }
-          }
+          "$ref": "#/definitions/dataGovernance"
+        }
+      }
+    },
+    "dataGovernance": {
+      "type": "object",
+      "title": "Data Governance",
+      "additionalProperties": false,
+      "properties": {
+        "custodians": {
+          "type": "array",
+          "title": "Data Custodians",
+          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
+        },
+        "stewards": {
+          "type": "array",
+          "title": "Data Stewards",
+          "description": "Data stewards are responsible for data content, context, and associated business rules.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
+        },
+        "owners": {
+          "type": "array",
+          "title": "Data Owners",
+          "description": "Data owners are concerned with risk and appropriate access to data.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
         }
       }
     },

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -1826,6 +1826,7 @@ limitations under the License.
                                             <xs:documentation>Specifies the data classification.</xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
                                     <xs:element name="source" minOccurs="0" maxOccurs="1">
                                         <xs:annotation>
                                             <xs:documentation>The URI, URL, or BOM-Link of the components or services the data came in from.</xs:documentation>
@@ -3008,48 +3009,7 @@ limitations under the License.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="governance" minOccurs="0" maxOccurs="1">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="custodians" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation>
-                                    Data custodians are responsible for the safe custody, transport, and storage of data.
-                                </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="custodian" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="stewards" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation>
-                                    Data stewards are responsible for data content, context, and associated business rules.
-                                </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="steward" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="owners" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation>
-                                    Data owners are concerned with risk and appropriate access to data.
-                                </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="owner" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
+            <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
@@ -3059,6 +3019,47 @@ limitations under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataGovernance">
+        <xs:sequence>
+            <xs:element name="custodians" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data custodians are responsible for the safe custody, transport, and storage of data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="custodian" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="stewards" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data stewards are responsible for data content, context, and associated business rules.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="steward" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="owners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data owners are concerned with risk and appropriate access to data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="owner" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="organizationOrIndividualType">

--- a/tools/src/test/resources/1.5/valid-saasbom-1.5.json
+++ b/tools/src/test/resources/1.5/valid-saasbom-1.5.json
@@ -106,6 +106,15 @@
               "description": "Traffic to/from stock service to microservice-1",
               "classification": "PII",
               "flow": "bi-directional",
+              "governance": {
+                "owners": [
+                  {
+                    "organization": {
+                      "name": "Customer Name"
+                    }
+                  }
+                ]
+              },
               "source": [
                 "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#stock-ticker-service"
               ],

--- a/tools/src/test/resources/1.5/valid-saasbom-1.5.textproto
+++ b/tools/src/test/resources/1.5/valid-saasbom-1.5.textproto
@@ -31,6 +31,15 @@ services {
     value: "Customer"
     name: "Consumer to Stock Service",
     description: "Traffic to/from consumer to service"
+    governance: {
+      owners: [
+        {
+          organization: {
+            name: "Customer Name"
+          }
+        }
+      ]
+    },
     source: "https://0.0.0.0"
     destination: "https://0.0.0.0"
   }

--- a/tools/src/test/resources/1.5/valid-saasbom-1.5.xml
+++ b/tools/src/test/resources/1.5/valid-saasbom-1.5.xml
@@ -24,6 +24,15 @@
             <data>
                 <dataflow name="Consumer to Stock Service" description="Traffic to/from consumer to service">
                     <classification flow="bi-directional">Customer</classification>
+                    <governance>
+                        <owners>
+                            <owner>
+                                <organization>
+                                    <name>Customer Name</name>
+                                </organization>
+                            </owner>
+                        </owners>
+                    </governance>
                     <source>
                         <url>https://0.0.0.0</url>
                     </source>


### PR DESCRIPTION
Data governance was added as part of ML support, however, governance should have been applied to #194 but was missed. This PR corrects that oversight.