### PR TITLE
Introduce type for BOM-Link

### DIFF
--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -117,6 +117,26 @@
       "$comment": "Identifier-DataType for interlinked elements.",
       "type": "string"
     },
+    "bomLinkDocumentType": {
+      "title": "BOM-Link document",
+      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLinkElementType": {
+      "title": "BOM-Link element",
+      "description": "Descriptor for an element in another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLink": {
+      "anyOf": [
+        {"$ref": "#/definitions/bomLinkDocumentType"},
+        {"$ref": "#/definitions/bomLinkElementType"}
+      ]
+    },
     "metadata": {
       "type": "object",
       "title": "BOM Metadata Object",

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -42,6 +42,34 @@ limitations under the License.
         <xs:restriction base="xs:string" />
     </xs:simpleType>
 
+    <xs:simpleType name="bomLinkDocumentType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Descriptor for another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})/[1-9][0-9]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkElementType">
+        <xs:annotation>
+            <xs:documentation  xml:lang="en">
+                Descriptor for an element in another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})/[1-9][0-9]*#.+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkType">
+        <xs:union memberTypes="bom:bomLinkDocumentType bom:bomLinkElementType"/>
+    </xs:simpleType>
+
     <xs:complexType name="metadata">
         <xs:sequence minOccurs="0" maxOccurs="1">
             <xs:element name="timestamp" type="xs:dateTime" minOccurs="0">


### PR DESCRIPTION
caused by #217 

Introduction of `bomLink` types,
so that they can be used where needed, later.

This should allow formulating the answer for #136 and #217 in the schema,
so that there would be clarity.
