### PR TITLE
validate JSON test data against schema - JS

### DIFF
--- a/tools/src/test/js/README.md
+++ b/tools/src/test/js/README.md
@@ -5,7 +5,7 @@ for validation of a schema.
 
 ## requirements
 
-* node >=16
+* node >=18.3
 
 ## setup
 

--- a/tools/src/test/js/json-schema-functional-tests.js
+++ b/tools/src/test/js/json-schema-functional-tests.js
@@ -1,0 +1,116 @@
+"use strict";
+
+/**
+ * validate all test data for a given version of CycloneDX.
+ * call the script via `node <this-file> -v <CDX-version>`
+ */
+
+import {readFile, stat} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parseArgs} from 'node:util'
+
+import Ajv from "ajv"
+import addFormats from "ajv-formats"
+import addFormats2019 from "ajv-formats-draft2019"
+import {globSync} from 'glob'
+
+
+const _thisDir = dirname(fileURLToPath(import.meta.url))
+
+// region config
+
+const testschemaVersion = (parseArgs({options: {v: {type: 'string', short: 'v'}}}).values.v ?? '').trim()
+const schemaDir = join(_thisDir, '..', '..', '..', '..', 'schema')
+const schemaFile = join(schemaDir, `bom-${testschemaVersion}.schema.json`)
+const testdataDir = join(_thisDir, '..', 'resources', testschemaVersion)
+
+if (testschemaVersion.length === 0) {
+    throw new Error('missing testschemaVersion. expected via argument')
+}
+console.debug('DEBUG | testschemaVersion = ', testschemaVersion);
+
+if (!await stat(schemaFile).then(s => s.isFile()).catch(() => false)) {
+    throw new Error(`missing schemaFile: ${schemaFile}`);
+}
+console.debug('DEBUG | schemaFile = ', schemaFile);
+
+if (!await stat(testdataDir).then(s => s.isDirectory()).catch(() => false)) {
+    throw new Error(`missing testdataDir: ${testdataDir}`);
+}
+console.debug('DEBUG | testdataDir = ', testdataDir);
+
+// endregion config
+
+// region validator
+
+const [spdxSchema, jsfSchema, bomSchema] = await Promise.all([
+    readFile(join(schemaDir, 'spdx.schema.json'), 'utf-8').then(JSON.parse),
+    readFile(join(schemaDir, 'jsf-0.82.schema.json'), 'utf-8').then(JSON.parse),
+    readFile(schemaFile, 'utf-8').then(JSON.parse)
+])
+
+const ajv = new Ajv({
+    // not running in strict - this is done in the linter-test already
+    strict: false,
+    validateFormats: true,
+    addUsedSchema: false,
+    schemas: {
+        'http://cyclonedx.org/schema/spdx.schema.json': spdxSchema,
+        'http://cyclonedx.org/schema/jsf-0.82.schema.json': jsfSchema
+    }
+});
+addFormats(ajv)
+addFormats2019(ajv, {formats: ['idn-email']})
+// there is just no working implementation for format "iri-reference"
+// see https://github.com/luzlab/ajv-formats-draft2019/issues/22
+ajv.addFormat('iri-reference', true)
+if (testschemaVersion === '1.2') {
+    // CycloneDX 1.2 had a wrong undefined format `string`.
+    // Let's ignore this format only for this special version.
+    ajv.addFormat('string', true)
+}
+const _ajvValidate = ajv.compile(bomSchema)
+
+/**
+ * @param {string} file - file path to validate
+ * @return {null|object}
+ */
+async function validateFile(file) {
+    return _ajvValidate(await readFile(file, 'utf-8').then(JSON.parse))
+        ? null
+        : _ajvValidate.errors
+}
+
+// endregion validator
+
+let errCnt = 0
+
+for (const file of globSync(join(testdataDir, 'valid-*.json'))) {
+    console.log('\ntest', file, '...');
+    const validationErrors = await validateFile(file)
+    if (validationErrors === null) {
+        console.log('OK.')
+    } else {
+        ++errCnt;
+        console.error('ERROR: Unexpected validation error for file:', file);
+        console.error(validationErrors)
+    }
+}
+
+for (const file of globSync(join(testdataDir, 'invalid-*.json'))) {
+    console.log('\ntest', file, '...');
+    const validationErrors = await validateFile(file)
+    if (validationErrors === null) {
+        ++errCnt;
+        console.error('ERROR: Missing expected validation error for file:', file);
+
+    } else {
+        console.log('OK.')
+    }
+}
+
+
+// Exit statuses should be in the range 0 to 254.
+// The status 0 is used to terminate the program successfully.
+process.exitCode = Math.min(errCnt, 254)

--- a/tools/src/test/js/json-schema-lint-tests.js
+++ b/tools/src/test/js/json-schema-lint-tests.js
@@ -1,9 +1,9 @@
 "use strict";
 
-import assert from 'assert'
-import {readFile} from 'fs/promises'
-import {dirname, basename, join} from 'path'
-import {fileURLToPath} from 'url'
+import assert from 'node:assert'
+import {readFile} from 'node:fs/promises'
+import {dirname, basename, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
 
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'

--- a/tools/src/test/js/package.json
+++ b/tools/src/test/js/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=16"
+    "node": ">=18.3"
   },
   "dependencies": {
     "ajv": "^8.12.0",
@@ -12,10 +12,15 @@
     "npm-run-all": "^4.1.5"
   },
   "devDependencies": {
-    "@types/node": ">=16"
+    "@types/node": ">=18.3"
   },
   "scripts": {
     "test": "run-s test:*",
-    "test:json-schema-lint": "node -- json-schema-lint-tests.js"
+    "test:json-schema-lint": "node -- json-schema-lint-tests.js",
+    "test:json-schema-functional": "run-s test:json-schema-functional:*",
+    "test:json-schema-functional:1.5": "node -- json-schema-functional-tests.js -v 1.5",
+    "test:json-schema-functional:1.4": "node -- json-schema-functional-tests.js -v 1.4",
+    "test:json-schema-functional:1.3": "node -- json-schema-functional-tests.js -v 1.3",
+    "test:json-schema-functional:1.2": "node -- json-schema-functional-tests.js -v 1.2"
   }
 }


### PR DESCRIPTION
yet another json schema runner, that validates the [exiting test data](https://github.com/CycloneDX/specification/tree/v1.5-dev/tools/src/test/resources).
here `AJV` is used to validate json. it is yet another implementation of json schema.
one that might be more or less strict to the standards.

I left out the XML validation, because we already have one that utilizes `libxml2` - the PHP does that.


similar to #238 
