### PR TITLE
V1.5 dev resourceReferenceChoice ref clarifications

### DIFF
--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -3645,7 +3645,10 @@
         "ref": {
           "title": "BOM Reference",
           "description": "References an object by its bom-ref attribute",
-          "$ref": "#/definitions/refLinkType"
+          "anyOf": [
+            {"$ref": "#/definitions/refLinkType"},
+            {"$ref": "#/definitions/bomLinkElementType"}
+          ]
         },
         "externalReference": {
           "title": "External reference",

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -3645,7 +3645,7 @@
         "ref": {
           "title": "BOM Reference",
           "description": "References an object by its bom-ref attribute",
-          "$ref": "#/definitions/refType"
+          "$ref": "#/definitions/refLinkType"
         },
         "externalReference": {
           "title": "External reference",

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -4356,7 +4356,7 @@ limitations under the License.
     <xs:complexType name="resourceReferenceType">
         <xs:sequence>
             <xs:choice>
-                <xs:element name="ref" type="bom:refType" minOccurs="1" maxOccurs="1">
+                <xs:element name="ref" type="bom:refLinkType" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             References an object by its bom-ref attribute

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -4356,12 +4356,15 @@ limitations under the License.
     <xs:complexType name="resourceReferenceType">
         <xs:sequence>
             <xs:choice>
-                <xs:element name="ref" type="bom:refLinkType" minOccurs="1" maxOccurs="1">
+                <xs:element name="ref" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             References an object by its bom-ref attribute
                         </xs:documentation>
                     </xs:annotation>
+                    <xs:simpleType>
+                        <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                    </xs:simpleType>
                 </xs:element>
                 <xs:element name="externalReference" type="bom:externalReference" minOccurs="1" maxOccurs="1">
                     <xs:annotation>


### PR DESCRIPTION
@mrutkows could you help improve the schema in terms of documentation? 
the `resourceReferenceChoice.ref` is intended to link to a `bom-ref`.

Question: Must this link to a `bom-ref` in the **same** document, or would it also be okay to link to a `bom-ref` in **another** document aswell, using a [BOM-Link](https://cyclonedx.org/capabilities/bomlink/)? 
depending on your answer, I might need to modify the content of this PR.

see comments below ...

----
there was some documentation enhancement brought into the schema to make this much clearer.
followup of #236 & #222
caused by #136 and #217