### PR TITLE
v1.5 complete linkable licenses

### DIFF
--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -931,8 +931,8 @@
           "maxItems": 1,
           "items": [{
             "type": "object",
-            "required": ["expression"],
             "additionalProperties": false,
+            "required": ["expression"],
             "properties": {
               "expression": {
                 "type": "string",
@@ -941,6 +941,11 @@
                   "Apache-2.0 AND (MIT OR GPL-2.0-only)",
                   "GPL-3.0-only WITH Classpath-exception-2.0"
                 ]
+              },
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
               }
             }
           }]

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -2064,11 +2064,25 @@ limitations under the License.
     <xs:complexType name="licenseChoiceType">
         <xs:choice>
             <xs:element name="license" type="bom:licenseType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="expression" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+            <xs:element name="expression" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>A valid SPDX license expression.
                         Refer to https://spdx.org/specifications for syntax requirements</xs:documentation>
                 </xs:annotation>
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:normalizedString">
+                            <xs:attribute name="bom-ref" type="bom:refType">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        An optional identifier which can be used to reference the license elsewhere in the BOM.
+                                        Uniqueness is enforced within all elements and children of the root-level bom element.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
             </xs:element>
         </xs:choice>
     </xs:complexType>

--- a/tools/src/test/resources/1.5/valid-license-expression-1.5.json
+++ b/tools/src/test/resources/1.5/valid-license-expression-1.5.json
@@ -12,7 +12,8 @@
       "version": "9.0.14",
       "licenses": [
         {
-          "expression": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"
+          "expression": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+          "bom-ref": "my-license"
         }
       ]
     }

--- a/tools/src/test/resources/1.5/valid-license-expression-1.5.xml
+++ b/tools/src/test/resources/1.5/valid-license-expression-1.5.xml
@@ -15,7 +15,9 @@
                 <hash alg="SHA-512">e8f33e424f3f4ed6db76a482fde1a5298970e442c531729119e37991884bdffab4f9426b7ee11fccd074eeda0634d71697d6f88a460dce0ac8d627a29f7d1282</hash>
             </hashes>
             <licenses>
-                <expression>EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0</expression>
+                <expression bom-ref="my-license">
+                    EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+                </expression>
             </licenses>
             <purl>pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar</purl>
         </component>

--- a/tools/src/test/resources/1.5/valid-license-id-1.5.json
+++ b/tools/src/test/resources/1.5/valid-license-id-1.5.json
@@ -13,7 +13,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "bom-ref": "my-license"
           }
         }
       ]

--- a/tools/src/test/resources/1.5/valid-license-id-1.5.xml
+++ b/tools/src/test/resources/1.5/valid-license-id-1.5.xml
@@ -15,7 +15,7 @@
                 <hash alg="SHA-512">e8f33e424f3f4ed6db76a482fde1a5298970e442c531729119e37991884bdffab4f9426b7ee11fccd074eeda0634d71697d6f88a460dce0ac8d627a29f7d1282</hash>
             </hashes>
             <licenses>
-                <license>
+                <license bom-ref="my-license">
                     <id>Apache-2.0</id>
                 </license>
             </licenses>

--- a/tools/src/test/resources/1.5/valid-license-name-1.5.json
+++ b/tools/src/test/resources/1.5/valid-license-name-1.5.json
@@ -13,7 +13,8 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache License 2.0"
+            "name": "Apache License 2.0",
+            "bom-ref": "my-license"
           }
         }
       ]

--- a/tools/src/test/resources/1.5/valid-license-name-1.5.xml
+++ b/tools/src/test/resources/1.5/valid-license-name-1.5.xml
@@ -15,7 +15,7 @@
                 <hash alg="SHA-512">e8f33e424f3f4ed6db76a482fde1a5298970e442c531729119e37991884bdffab4f9426b7ee11fccd074eeda0634d71697d6f88a460dce0ac8d627a29f7d1282</hash>
             </hashes>
             <licenses>
-                <license>
+                <license bom-ref="my-license">
                     <name>Apache License 2.0</name>
                 </license>
             </licenses>


### PR DESCRIPTION
currently, all named- and SPDX-licenses were linkable, as they had a bom-ref.
the SPDX licen expression did not have one, yet.
to  make it linkable (in licensing-docs), it is needed to add a `bom-ref` to the license expression, too. 

- add examples for licenses with links
- add `bom-ref` to license expressions, so ALL licenses are linkable

