### PR TITLE
adjust default values

### DIFF
--- a/schema/bom-1.5.proto
+++ b/schema/bom-1.5.proto
@@ -4,7 +4,7 @@ import "google/protobuf/timestamp.proto";
 
 // Specifies attributes of the text
 message AttachedText {
-  // Specifies the content type of the text. Defaults to text/plain if not specified.
+  // Specifies the content type of the text. Defaults to 'text/plain' if not specified.
   optional string content_type = 1;
   // Specifies the optional encoding the text is represented in
   optional string encoding = 2;
@@ -103,7 +103,7 @@ message Component {
   string version = 9;
   // Specifies a description for the component
   optional string description = 10;
-  // Specifies the scope of the component. If scope is not specified, 'runtime' scope should be assumed by the consumer of the BOM
+  // Specifies the scope of the component. If scope is not specified, SCOPE_REQUIRED scope should be assumed by the consumer of the BOM
   optional Scope scope = 11;
   repeated Hash hashes = 12;
   repeated LicenseChoice licenses = 13;
@@ -572,11 +572,11 @@ message Swid {
   string tag_id = 1;
   // Maps to the name of a SoftwareIdentity.
   string name = 2;
-  // Maps to the version of a SoftwareIdentity.
+  // Maps to the version of a SoftwareIdentity. Defaults to '0.0' if not specified.
   optional string version = 3;
-  // Maps to the tagVersion of a SoftwareIdentity.
+  // Maps to the tagVersion of a SoftwareIdentity. Defaults to '0' if not specified.
   optional int32 tag_version = 4;
-  // Maps to the patch of a SoftwareIdentity.
+  // Maps to the patch of a SoftwareIdentity. Defaults to 'false' if not specified.
   optional bool patch = 5;
   // Specifies the full content of the SWID tag.
   optional AttachedText text = 6;
@@ -959,7 +959,7 @@ message VulnerabilityAffectedVersions {
     // A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst
     string range = 2;
   }
-  // The vulnerability status for the version or range of versions.
+  // The vulnerability status for the version or range of versions. Defaults to VULNERABILITY_AFFECTED_STATUS_AFFECTED if not specified.
   optional VulnerabilityAffectedStatus status = 3;
 }
 

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -6,8 +6,7 @@
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -474,7 +474,7 @@ limitations under the License.
                     <xs:documentation>Specifies a description for the component</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1">
+            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1" default="required">
                 <xs:annotation>
                     <xs:documentation>Specifies the scope of the component. If scope is not specified, 'required'
                         scope SHOULD be assumed by the consumer of the BOM.</xs:documentation>


### PR DESCRIPTION
fixes #78
see #216

----- 


## changes 
* Proto
  * document the defaults that are already formulated in XML and JSON
* JSON 
  * `bom.version` is no longer required. it already has a default value to which it falls back if omitted. 
    it already is optional in XML.
    see #78
* XML
  * `component.scope` now defaults to `required`
    * already documented to fall back to value `required` in XML
    * in JSON it has a default of `required` already
