### PR TITLE
testcases: license with no `id` nor `name` #228

### DIFF
--- a/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.json
+++ b/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.json
@@ -1,0 +1,18 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "name": "license-with-no-id-nor-name",
+      "version": "23",
+      "description": "testcase for issue#288",
+      "licenses": [
+        {
+          "license": {}
+        }
+      ]
+    }
+  ]
+}

--- a/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.textproto
+++ b/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.textproto
@@ -1,0 +1,12 @@
+spec_version: "1.5"
+version: 1
+serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+components {
+  type: CLASSIFICATION_LIBRARY
+  name: "license-with-no-id-nor-name"
+  version: "23"
+  description: "testcase for issue#288"
+  licenses {
+    license {}
+  }
+}

--- a/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.xml
+++ b/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+    <components>
+        <component type="library">
+            <name>license-with-no-id-nor-name</name>
+            <version>23</version>
+            <description>testcase for issue#288</description>
+            <licenses>
+                <license />
+            </licenses>
+        </component>
+    </components>
+</bom>


### PR DESCRIPTION
test cases for #228

shows false positives, just as prediceted by #228 

false-positive:
- https://github.com/CycloneDX/specification/actions/runs/6057628189/job/16438977255#step:5:808
  ```text
  test /home/runner/work/specification/specification/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.xml ...
  ERROR: Missing expected validation error for file: /home/runner/work/specification/specification/tools/src/test/resources/1.5/invalid-license-missing-id-and-name.xml
  ```