### PR TITLE
Fix test data, closes #294

### DIFF
--- a/tools/src/test/resources/1.2/valid-service-1.2.json
+++ b/tools/src/test/resources/1.2/valid-service-1.2.json
@@ -5,7 +5,7 @@
   "version": 1,
   "components": [
     {
-      "bom-ref": "pkg:npm/acme/component@1.0.0",
+      "bom-ref": "pkg:maven/com.acme/stock-java-client@1.0.12",
       "type": "library",
       "publisher": "Acme Inc",
       "group": "com.acme",

--- a/tools/src/test/resources/1.3/valid-service-1.3.json
+++ b/tools/src/test/resources/1.3/valid-service-1.3.json
@@ -5,7 +5,7 @@
   "version": 1,
   "components": [
     {
-      "bom-ref": "pkg:npm/acme/component@1.0.0",
+      "bom-ref": "pkg:maven/com.acme/stock-java-client@1.0.12",
       "type": "library",
       "publisher": "Acme Inc",
       "group": "com.acme",

--- a/tools/src/test/resources/1.3/valid-service-1.3.textproto
+++ b/tools/src/test/resources/1.3/valid-service-1.3.textproto
@@ -3,7 +3,7 @@ version: 1
 serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
 components {
   type: CLASSIFICATION_LIBRARY
-  bom_ref: "pkg:npm/acme/component@1.0.0"
+  bom_ref: "pkg:maven/com.acme/stock-java-client@1.0.12"
   publisher: "Acme Inc"
   group: "com.acme"
   name: "stock-java-client"

--- a/tools/src/test/resources/1.4/valid-service-1.4.json
+++ b/tools/src/test/resources/1.4/valid-service-1.4.json
@@ -5,7 +5,7 @@
   "version": 1,
   "components": [
     {
-      "bom-ref": "pkg:npm/acme/component@1.0.0",
+      "bom-ref": "pkg:maven/com.acme/stock-java-client@1.0.12",
       "type": "library",
       "publisher": "Acme Inc",
       "group": "com.acme",

--- a/tools/src/test/resources/1.4/valid-service-1.4.textproto
+++ b/tools/src/test/resources/1.4/valid-service-1.4.textproto
@@ -3,7 +3,7 @@ version: 1
 serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
 components {
   type: CLASSIFICATION_LIBRARY
-  bom_ref: "pkg:npm/acme/component@1.0.0"
+  bom_ref: "pkg:maven/com.acme/stock-java-client@1.0.12"
   publisher: "Acme Inc"
   group: "com.acme"
   name: "stock-java-client"

--- a/tools/src/test/resources/1.5/valid-service-1.5.json
+++ b/tools/src/test/resources/1.5/valid-service-1.5.json
@@ -5,7 +5,7 @@
   "version": 1,
   "components": [
     {
-      "bom-ref": "pkg:npm/acme/component@1.0.0",
+      "bom-ref": "pkg:maven/com.acme/stock-java-client@1.0.12",
       "type": "library",
       "publisher": "Acme Inc",
       "group": "com.acme",

--- a/tools/src/test/resources/1.5/valid-service-1.5.textproto
+++ b/tools/src/test/resources/1.5/valid-service-1.5.textproto
@@ -3,7 +3,7 @@ version: 1
 serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
 components {
   type: CLASSIFICATION_LIBRARY
-  bom_ref: "pkg:npm/acme/component@1.0.0"
+  bom_ref: "pkg:maven/com.acme/stock-java-client@1.0.12"
   publisher: "Acme Inc"
   group: "com.acme"
   name: "stock-java-client"


### PR DESCRIPTION
Fixes an inconsistency in test data of valid-service. First experienced in valid-service-1.4.json, other files (other versions and filetypes) showed the same deviation. The fix was derived from working test data of valid-service.

closes #294