### PR TITLE
chore: add `@CycloneDX/core-team` as default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# all Core Team members are default-reviewers of new pull requests.
+# see https://github.com/orgs/CycloneDX/teams/core-team
+*  @CycloneDX/core-team


### PR DESCRIPTION
in the past i set the `reviewers` manually.
i want this to be automated... so here is a technical solution that works for github.