### PR TITLE
Fix `bom-ref` in test data `valid-compositions`

### DIFF
--- a/tools/src/test/resources/1.3/valid-compositions-1.3.json
+++ b/tools/src/test/resources/1.3/valid-compositions-1.3.json
@@ -29,6 +29,7 @@
       ]
     },
     {
+      "bom-ref": "pkg:maven/acme/library@3.0",
       "type": "library",
       "name": "Acme Library",
       "version": "3.0",

--- a/tools/src/test/resources/1.3/valid-compositions-1.3.textproto
+++ b/tools/src/test/resources/1.3/valid-compositions-1.3.textproto
@@ -25,6 +25,7 @@ components {
 }
 components {
   type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/acme/library@3.0"
   name: "Acme Library"
   version: "3.0"
   purl: "pkg:maven/acme/library@3.0"

--- a/tools/src/test/resources/1.4/valid-compositions-1.4.json
+++ b/tools/src/test/resources/1.4/valid-compositions-1.4.json
@@ -29,6 +29,7 @@
       ]
     },
     {
+      "bom-ref": "pkg:maven/acme/library@3.0",
       "type": "library",
       "name": "Acme Library",
       "version": "3.0",

--- a/tools/src/test/resources/1.4/valid-compositions-1.4.textproto
+++ b/tools/src/test/resources/1.4/valid-compositions-1.4.textproto
@@ -25,6 +25,7 @@ components {
 }
 components {
   type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/acme/library@3.0"
   name: "Acme Library"
   version: "3.0"
   purl: "pkg:maven/acme/library@3.0"

--- a/tools/src/test/resources/1.5/valid-compositions-1.5.json
+++ b/tools/src/test/resources/1.5/valid-compositions-1.5.json
@@ -29,6 +29,7 @@
       ]
     },
     {
+      "bom-ref": "pkg:maven/acme/library@3.0",
       "type": "library",
       "name": "Acme Library",
       "version": "3.0",

--- a/tools/src/test/resources/1.5/valid-compositions-1.5.textproto
+++ b/tools/src/test/resources/1.5/valid-compositions-1.5.textproto
@@ -25,6 +25,7 @@ components {
 }
 components {
   type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/acme/library@3.0"
   name: "Acme Library"
   version: "3.0"
   purl: "pkg:maven/acme/library@3.0"

--- a/tools/src/test/resources/1.6/valid-compositions-1.6.json
+++ b/tools/src/test/resources/1.6/valid-compositions-1.6.json
@@ -29,6 +29,7 @@
       ]
     },
     {
+      "bom-ref": "pkg:maven/acme/library@3.0",
       "type": "library",
       "name": "Acme Library",
       "version": "3.0",

--- a/tools/src/test/resources/1.6/valid-compositions-1.6.textproto
+++ b/tools/src/test/resources/1.6/valid-compositions-1.6.textproto
@@ -25,6 +25,7 @@ components {
 }
 components {
   type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/acme/library@3.0"
   name: "Acme Library"
   version: "3.0"
   purl: "pkg:maven/acme/library@3.0"


### PR DESCRIPTION
forward-port of #302
fixes #301 in 1.6