### PR TITLE
CBOM: merges relatedCryptoMaterial and key asset types

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -3828,7 +3828,6 @@
           "enum": [
             "algorithm",
             "certificate",
-            "key",
             "protocol",
             "relatedCryptoMaterial"
           ]
@@ -4228,127 +4227,102 @@
             }
           }
         },
-        "keyProperties": {
-          "type": "object",
-          "title": "Properties for Keys",
-          "description": "Properties for crypto assets of asset type 'key'",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "key type",
-              "description": "The type of the key",
-              "enum": [
-                "privateKey",
-                "publicKey",
-                "secretKey"
-              ]
-            },
-            "id": {
-              "type": "string",
-              "title": "key id",
-              "description": "The identifier for the key"
-            },
-            "state": {
-              "type": "string",
-              "title": "key state",
-              "description": "The key state according to NIST SP 800-57",
-              "enum": [
-                "preActivation",
-                "active",
-                "suspended",
-                "deactivated",
-                "compromised",
-                "destroyed"
-              ]
-            },
-            "size": {
-              "type": "integer",
-              "title": "Crypto asset size (in bits)",
-              "description": "Size of the crypto asset (in bits)"
-            },
-            "keyAlgorithmRef": {
-              "$ref": "#/definitions/cryptoRef",
-              "title": "Algorithm reference",
-              "description": "Bom-ref to algorithm used to generate the key"
-            },
-            "securedBy": {
-              "$ref": "#/definitions/securedBy",
-              "title": "Crypto asset is secured by"
-            },
-            "creationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "creation date",
-              "description": "The date and time (timestamp) when the key was created."
-            },
-            "activationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "activation date",
-              "description": "The date and time (timestamp) when the key was activated."
-            },
-            "updateDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "update date",
-              "description": "The date and time (timestamp) when the key was updated."
-            },
-            "expirationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "expiration date",
-              "description": "The date and time (timestamp) when the key expired."
-            }
-          }
-        },
         "relatedCryptoMaterialProperties": {
           "type": "object",
           "title": "related crypto material properties",
           "description": "Properties for crypto assets of asset type 'relatedCryptoMaterial'",
           "additionalProperties": false,
           "properties": {
-            "type": {
-              "type": "string",
-              "title": "relatedCryptoMaterialType",
-              "description": "The type for the related crypto material",
-              "enum": [
-                "ciphertext",
-                "signature",
-                "digest",
-                "initializationVector",
-                "nonce",
-                "seed",
-                "salt",
-                "sharedSecret",
-                "tag",
-                "additionalData",
-                "password",
-                "credential",
-                "token",
-                "other",
-                "unknown"
-              ]
-            },
-            "value": {
-              "type": "string",
-              "title": "Value assosiated to the crypto material",
-              "description": "The assosiated value of the crypto material"
-            },
-            "size": {
-              "type": "integer",
-              "title": "Crypto asset size (in bits)",
-              "description": "Size of the crypto asset (in bits)"
-            },
-            "format": {
-              "type": "string",
-              "title": "format",
-              "description": "format of the related crypto material (e.g. P8, PEM, DER)"
-            },
-            "securedBy": {
-              "$ref": "#/definitions/securedBy",
-              "title": "Crypto asset is secured by"
-            }
+              "type": {
+                  "type": "string",
+                  "title": "relatedCryptoMaterialType",
+                  "description": "The type for the related crypto material",
+                  "enum": [
+                      "privateKey",
+                      "publicKey",
+                      "secretKey",
+                      "ciphertext",
+                      "signature",
+                      "digest",
+                      "initializationVector",
+                      "nonce",
+                      "seed",
+                      "salt",
+                      "sharedSecret",
+                      "tag",
+                      "additionalData",
+                      "password",
+                      "credential",
+                      "token",
+                      "other",
+                      "unknown"
+                  ]
+              },
+              "id": {
+                  "type": "string",
+                  "title": "key id",
+                  "description": "The identifier for the key"
+              },
+              "state": {
+                  "type": "string",
+                  "title": "key state",
+                  "description": "The key state according to NIST SP 800-57",
+                  "enum": [
+                      "preActivation",
+                      "active",
+                      "suspended",
+                      "deactivated",
+                      "compromised",
+                      "destroyed"
+                  ]
+              },
+              "algorithmRef": {
+                  "$ref": "#/definitions/cryptoRef",
+                  "title": "Algorithm reference",
+                  "description": "Bom-ref to algorithm used to generate the relatedCryptoMaterial"
+              },
+              "creationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "creation date",
+                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was created."
+              },
+              "activationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "activation date",
+                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was activated."
+              },
+              "updateDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "update date",
+                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was updated."
+              },
+              "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "expiration date",
+                  "description": "The date and time (timestamp) when the relatedCryptoMaterial expired."
+              },
+              "value": {
+                  "type": "string",
+                  "title": "Value assosiated to the crypto material",
+                  "description": "The assosiated value of the crypto material"
+              },
+              "size": {
+                  "$ref": "#/definitions/size",
+                  "title": "Crypto asset size (in bits)"
+              },
+              "format": {
+                  "type": "string",
+                  "title": "format",
+                  "description": "format of the related crypto material (e.g. P8, PEM, DER)"
+              },
+              "securedBy": {
+                  "$ref": "#/definitions/securedBy",
+                  "title": "Crypto asset is secured by"
+              }
           }
         },
         "protocolProperties": {

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -4233,96 +4233,96 @@
           "description": "Properties for crypto assets of asset type 'relatedCryptoMaterial'",
           "additionalProperties": false,
           "properties": {
-              "type": {
-                  "type": "string",
-                  "title": "relatedCryptoMaterialType",
-                  "description": "The type for the related crypto material",
-                  "enum": [
-                      "privateKey",
-                      "publicKey",
-                      "secretKey",
-                      "ciphertext",
-                      "signature",
-                      "digest",
-                      "initializationVector",
-                      "nonce",
-                      "seed",
-                      "salt",
-                      "sharedSecret",
-                      "tag",
-                      "additionalData",
-                      "password",
-                      "credential",
-                      "token",
-                      "other",
-                      "unknown"
-                  ]
-              },
-              "id": {
-                  "type": "string",
-                  "title": "key id",
-                  "description": "The identifier for the key"
-              },
-              "state": {
-                  "type": "string",
-                  "title": "key state",
-                  "description": "The key state according to NIST SP 800-57",
-                  "enum": [
-                      "preActivation",
-                      "active",
-                      "suspended",
-                      "deactivated",
-                      "compromised",
-                      "destroyed"
-                  ]
-              },
-              "algorithmRef": {
-                  "$ref": "#/definitions/cryptoRef",
-                  "title": "Algorithm reference",
-                  "description": "Bom-ref to algorithm used to generate the relatedCryptoMaterial"
-              },
-              "creationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "creation date",
-                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was created."
-              },
-              "activationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "activation date",
-                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was activated."
-              },
-              "updateDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "update date",
-                  "description": "The date and time (timestamp) when the relatedCryptoMaterial was updated."
-              },
-              "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "expiration date",
-                  "description": "The date and time (timestamp) when the relatedCryptoMaterial expired."
-              },
-              "value": {
-                  "type": "string",
-                  "title": "Value assosiated to the crypto material",
-                  "description": "The assosiated value of the crypto material"
-              },
-              "size": {
-                  "$ref": "#/definitions/size",
-                  "title": "Crypto asset size (in bits)"
-              },
-              "format": {
-                  "type": "string",
-                  "title": "format",
-                  "description": "format of the related crypto material (e.g. P8, PEM, DER)"
-              },
-              "securedBy": {
-                  "$ref": "#/definitions/securedBy",
-                  "title": "Crypto asset is secured by"
-              }
+            "type": {
+                "type": "string",
+                "title": "relatedCryptoMaterialType",
+                "description": "The type for the related crypto material",
+                "enum": [
+                    "privateKey",
+                    "publicKey",
+                    "secretKey",
+                    "ciphertext",
+                    "signature",
+                    "digest",
+                    "initializationVector",
+                    "nonce",
+                    "seed",
+                    "salt",
+                    "sharedSecret",
+                    "tag",
+                    "additionalData",
+                    "password",
+                    "credential",
+                    "token",
+                    "other",
+                    "unknown"
+                ]
+            },
+            "id": {
+                "type": "string",
+                "title": "id",
+                "description": "The identifier for the relatedCryptoMaterial"
+            },
+            "state": {
+                "type": "string",
+                "title": "state",
+                "description": "The key state according to NIST SP 800-57",
+                "enum": [
+                    "preActivation",
+                    "active",
+                    "suspended",
+                    "deactivated",
+                    "compromised",
+                    "destroyed"
+                ]
+            },
+            "algorithmRef": {
+                "$ref": "#/definitions/cryptoRef",
+                "title": "Algorithm reference",
+                "description": "Bom-ref to algorithm used to generate the relatedCryptoMaterial"
+            },
+            "creationDate": {
+                "type": "string",
+                "format": "date-time",
+                "title": "creation date",
+                "description": "The date and time (timestamp) when the relatedCryptoMaterial was created."
+            },
+            "activationDate": {
+                "type": "string",
+                "format": "date-time",
+                "title": "activation date",
+                "description": "The date and time (timestamp) when the relatedCryptoMaterial was activated."
+            },
+            "updateDate": {
+                "type": "string",
+                "format": "date-time",
+                "title": "update date",
+                "description": "The date and time (timestamp) when the relatedCryptoMaterial was updated."
+            },
+            "expirationDate": {
+                "type": "string",
+                "format": "date-time",
+                "title": "expiration date",
+                "description": "The date and time (timestamp) when the relatedCryptoMaterial expired."
+            },
+            "value": {
+                "type": "string",
+                "title": "Value assosiated to the crypto material",
+                "description": "The assosiated value of the crypto material"
+            },
+            "size": {
+                "type": "integer",
+                "title": "Crypto asset size (in bits)"
+            },
+            "format": {
+                "type": "string",
+                "title": "format",
+                "description": "format of the related crypto material (e.g. P8, PEM, DER)"
+            },
+            "securedBy": {
+                "$ref": "#/definitions/securedBy",
+                "title": "Crypto asset is secured by"
+            }
           }
         },
         "protocolProperties": {


### PR DESCRIPTION
This addresses the use case described in https://github.com/IBM/CBOM/issues/31:
- Expiry and life cycle of any relatedCryptoMaterial (e.g. keys, tokens, password) should be expressible.

This is done by merging the "key" asset type and "relatedCryptoMaterial" to "relatedCryptoMaterial", which contains the needed properties.