### PR TITLE
Merges detectionContext properties with component evidence

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -1576,6 +1576,26 @@
                 "type": "string",
                 "title": "Location",
                 "description": "The location or path to where the component was found."
+              },
+              "lineNumber": {
+                "type": "integer",
+                "title": "Line Number",
+                "description": "The line number where the component was found."
+              },
+              "offset": {
+                "type": "integer",
+                "title": "Offset",
+                "description": "The offset where the component was found."
+              },
+              "symbol": {
+                "type": "string",
+                "title": "Symbol",
+                "description": "The symbol name that was found associated with the component."
+              },
+              "additionalContext": {
+                "type": "string",
+                "title": "Additional Context",
+                "description": "Any additional context of the detected component (e.g. a code snippet)."
               }
             }
           }
@@ -4433,125 +4453,6 @@
           "type": "string",
           "title": "OID",
           "description": "OID of crypto asset"
-        },
-        "confidenceLevels": {
-          "type": "object",
-          "additionalItems": false,
-          "title": "confidence levels",
-          "description": "confidence levels of the reported crypto properties",
-          "properties": {
-            "assetType": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "assetType confidence level"
-            },
-            "primitive": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "primitive confidence level"
-            },
-            "relatedCryptoMaterialType": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "related crypto material confidence level"
-            },
-            "variant": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "variant confidence level"
-            },
-            "mode": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "mode of opreation confidence level"
-            },
-            "padding": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "padding confidence level"
-            },
-            "cryptoFunctions": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "related crypto material confidence level"
-            },
-            "subjectName": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "subjectName confidence level"
-            },
-            "issuerName": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "issuerName confidence level"
-            },
-            "notValidBefore": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "notValidBefore confidence level"
-            },
-            "notValidAfter": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "notValidAfter confidence level"
-            },
-            "certificateAlgorithm": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "certificateAlgorithm confidence level"
-            },
-            "certificateSignatureAlgorithm": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "certificateSignatureAlgorithm confidence level"
-            },
-            "certificateFormat": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "certificateFormat confidence level"
-            },
-            "certificateExtension": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "certificateExtension confidence level"
-            },
-            "tlsCipherSuites": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "tlsCipherSuites confidence level"
-            },
-            "ikev2TransformTypes": {
-              "$ref": "#/definitions/confidenceLevel",
-              "title": "ikev2TransformTypes confidence level"
-            }
-          }
-        },
-        "detectionContext": {
-          "type": "array",
-          "additionalItems": false,
-          "title": "detection context",
-          "description": "Defines additional context metadata related to the detected crypto asset",
-          "items": {
-            "type": "object",
-            "title": "detection context",
-            "additionalProperties": false,
-            "properties": {
-              "filePath": {
-                "type": "string",
-                "title": "filePath",
-                "description": "File path of the detected crypto asset"
-              },
-              "lineNumbers": {
-                "type": "array",
-                "title": "lineNumbers",
-                "description": "Line numbers of the detected crypto asset"
-              },
-              "offsets": {
-                "type": "array",
-                "title": "offsets",
-                "description": "Offsets of the detected crypto asset"
-              },
-              "symbols": {
-                "type": "array",
-                "title": "symbols",
-                "description": "symbol names detected for the crypto asset"
-              },
-              "keywords": {
-                "type": "array",
-                "title": "keywords",
-                "description": "keywords detected for the crypto asset"
-              },
-              "additionalContext": {
-                "type": "string",
-                "title": "additionalContext",
-                "description": "additional context of the detected crypto asset (e.g. code snippet)"
-              }
-            }
-          }
         }
       }
     },

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -4461,11 +4461,6 @@
       "title": "Reference to a crypto asset",
       "description": "Reference (bom-ref) to the crypto asset used in this context"
     },
-    "confidenceLevel": {
-      "title": "ConfidenceLevel",
-      "description": "The ConfidenceLevel related to a property",
-      "type": "number"
-    },
     "cipherSuite": {
       "type": "object",
       "title": "Cipher suite",


### PR DESCRIPTION
This PR follows our CBOM WG call from Oct 12. It removes the `detectionContext` property from components and merges them with `componentEvidence`. The following properties are added to evidence:
- `lineNumber`
- `offset`
- `symbol`
- `additionalContext`

The plan is to make a separate proposal/PR for `keyword`

The PR also removes the extra fields for confidence levels since they are already covered by `componentEvidence`.

Tagging @stevespringett @n1ckl0sk0rtge @mrutkows 