### PR TITLE
[DRAFT] extraneous components and version range constraints

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -892,6 +892,10 @@
           "title": "Component Version",
           "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
         },
+        "versionRange": {
+          "$ref": "#/definitions/versionRange",
+          "title": "Component Version Range"
+        },
         "description": {
           "type": "string",
           "title": "Component Description",
@@ -912,6 +916,12 @@
           "title": "Component Scope",
           "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
           "default": "required"
+        },
+        "isExtraneous": {
+          "type": "boolean",
+          "title": "Component Is Extraneous",
+          "description": "Whether this component is extraneous.\nAn extraneous component is not part of an assembly, but are (expected to be) provided by the environment, regardless of the component's `scope`.",
+          "default": false
         },
         "hashes": {
           "type": "array",
@@ -1037,7 +1047,18 @@
           "title": "Signature",
           "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
-      }
+      },
+      "allOf": [
+        {
+          "$comment": "property `version` and `versionRange` MUST NOT exist at the same time.",
+          "not": { "required": ["version", "versionRange"] }
+        },
+        {
+          "$comment": "`version-range` MUST only be present, if `isExtraneous` is `true`",
+          "if": { "properties": { "isExtraneous": { "const": false } } },
+          "then": { "not": { "required": ["versionRange"] } }
+        }
+      ]
     },
     "swid": {
       "type": "object",

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -895,7 +895,7 @@
         "versionRange": {
           "$ref": "#/definitions/versionRange",
           "title": "Component Version Range",
-          "description": "The component version range that may be provided to fulfill this capability.\nMay only occur if `isExtraneous` is `true`."
+          "description": "The component version range that may be provided to fulfill this capability.\nMAY only occur if `isExtraneous` is `true`."
         },
         "description": {
           "type": "string",
@@ -1057,7 +1057,8 @@
         {
           "$comment": "`version-range` MUST only be present, if `isExtraneous` is `true`",
           "if": { "properties": { "isExtraneous": { "const": false } } },
-          "then": { "not": { "required": ["versionRange"] } }
+          "then": { "not": { "required": ["versionRange"] } },
+          "else": true
         }
       ]
     },

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -895,7 +895,8 @@
         "versionRange": {
           "$ref": "#/definitions/versionRange",
           "title": "Component Version Range",
-          "description": "The component version range that may be provided to fulfill this capability.\nMAY only occur if `isExtraneous` is `true`."
+          "description": "The component version range that may be provided to fulfill this capability.\nMAY only occur if property `isExtraneous` is set to 'true'.",
+          "$comment": "a rule is taking cate of the plausibility between `version`/`versionRange` and `isExtraneous`=='true'"
         },
         "description": {
           "type": "string",

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -894,7 +894,8 @@
         },
         "versionRange": {
           "$ref": "#/definitions/versionRange",
-          "title": "Component Version Range"
+          "title": "Component Version Range",
+          "description": "The component version range that may be provided to fulfill this capability.\nMay only occur if `isExtraneous` is `true`."
         },
         "description": {
           "type": "string",

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -512,7 +512,7 @@ limitations under the License.
                         <xs:documentation>The component version range that may be provided to fulfill this capability.
                             MAY only occur if attribute `isExtraneous` is set to `true`.</xs:documentation>
                         <!-- Attention:
-                        Since XSD 1.1 `asserts` are mostly not implemented, there is currently no rule in this XSD,
+                        Since XSD 1.1 `asserts` are mostly not implemented, there is currently no rule in this XSD
                         that is taking cate of the plausibility between `version`/`versionRange` and `isExtraneous`=='true'
                         -->
                     </xs:annotation>
@@ -697,7 +697,7 @@ limitations under the License.
         This would be formal, if the support for XSD1.1's `assert` was properly implemented in validators and tools digesting XML.
         <xs:assert id="versionRange_requires_isExtraneous_eq_true"
                    test="if (versionRange) then (@isExtraneous eq 'true') else true()">
-            Child `versionRange` MAY only be present, if attribute `isExtraneous` is 'true'.
+            Child `versionRange` MAY only be present, if attribute `isExtraneous`=='true'.
         </xs:assert>
         -->
     </xs:complexType>

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -500,12 +500,20 @@ limitations under the License.
                         of the component. Examples: commons-lang3 and jquery</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="version" type="bom:versionType" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>The component version. The version should ideally comply with semantic versioning
-                        but is not enforced.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
+            <xs:choice>
+                <xs:element name="version" type="bom:versionType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The component version. The version should ideally comply with semantic versioning
+                            but is not enforced.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="versionRange" type="bom:versionRangeType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The component version range that may be provided to fulfill this capability.
+                            MAY only occur if `isExtraneous` is `true`.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
             <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Specifies a description for the component</xs:documentation>
@@ -667,12 +675,28 @@ limitations under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="isExtraneous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether this component is extraneous.
+                    An extraneous component is not part of an assembly, but are (expected to be) provided by the environment, regardless of the component's `scope`.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:anyAttribute namespace="##any" processContents="lax">
             <xs:annotation>
                 <xs:documentation>User-defined attributes may be used on this element as long as they
                     do not have the same name as an existing attribute used by the schema.</xs:documentation>
             </xs:annotation>
         </xs:anyAttribute>
+        <!--
+        this would be formal, if the support for XSD1.1's `assert` was properly implemented
+        in validators and tools digesting XML.
+        <xs:assert id="versionRange_requires_isExtraneous_eq_true"
+                   test="if (versionRange) then (@isExtraneous eq 'true') else true()">
+            child `versionRange` MAY only be present, if attribute `isExtraneous` is `true`
+        </xs:assert>
+        -->
     </xs:complexType>
 
     <xs:complexType name="licenseType">

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -510,7 +510,11 @@ limitations under the License.
                 <xs:element name="versionRange" type="bom:versionRangeType" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>The component version range that may be provided to fulfill this capability.
-                            MAY only occur if `isExtraneous` is `true`.</xs:documentation>
+                            MAY only occur if attribute `isExtraneous` is set to `true`.</xs:documentation>
+                        <!-- Attention:
+                        Since XSD 1.1 `asserts` are mostly not implemented, there is currently no rule in this XSD,
+                        that is taking cate of the plausibility between `version`/`versionRange` and `isExtraneous`=='true'
+                        -->
                     </xs:annotation>
                 </xs:element>
             </xs:choice>
@@ -689,12 +693,11 @@ limitations under the License.
                     do not have the same name as an existing attribute used by the schema.</xs:documentation>
             </xs:annotation>
         </xs:anyAttribute>
-        <!--
-        this would be formal, if the support for XSD1.1's `assert` was properly implemented
-        in validators and tools digesting XML.
+        <!-- Attention:
+        This would be formal, if the support for XSD1.1's `assert` was properly implemented in validators and tools digesting XML.
         <xs:assert id="versionRange_requires_isExtraneous_eq_true"
                    test="if (versionRange) then (@isExtraneous eq 'true') else true()">
-            child `versionRange` MAY only be present, if attribute `isExtraneous` is `true`
+            Child `versionRange` MAY only be present, if attribute `isExtraneous` is 'true'.
         </xs:assert>
         -->
     </xs:complexType>

--- a/tools/src/test/resources/1.6/informal-invalid-component-versionRange-non-extraneous-explicit.xml
+++ b/tools/src/test/resources/1.6/informal-invalid-component-versionRange-non-extraneous-explicit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <!--
+    this would be formal, if the support for XSD1.1's `assert` was properly implemented
+    in validators and tools digesting XML.
+    -->
+    <components>
+        <component type="library" isExtraneous="false">
+            <name>InvalidVersions</name>
+            <versionRange><![CDATA[>=9.0.0|<10.0.0]]></versionRange>
+            <description>versionRange may only exist on extraneous components, set `isExtraneous` explicit</description>
+        </component>
+    </components>
+</bom>

--- a/tools/src/test/resources/1.6/informal-invalid-component-versionRange-non-extraneous-implicit.xml
+++ b/tools/src/test/resources/1.6/informal-invalid-component-versionRange-non-extraneous-implicit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <!--
+    this would be formal, if the support for XSD1.1's `assert` was properly implemented
+    in validators and tools digesting XML.
+    -->
+    <components>
+        <component type="library">
+            <!-- @isExtraneous defaults to `false` -->
+            <name>InvalidVersions</name>
+            <versionRange><![CDATA[>=9.0.0|<10.0.0]]></versionRange>
+            <description>versionRange may only exist on extraneous components, set `isExtraneous` implicit by default value</description>
+        </component>
+    </components>
+</bom>

--- a/tools/src/test/resources/1.6/invalid-component-version-and-range.json
+++ b/tools/src/test/resources/1.6/invalid-component-version-and-range.json
@@ -1,0 +1,15 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "InvalidVersions",
+      "description": "may have `version` or `versionRange`, not both. This one does - it is invalid",
+      "version": "9.0.14",
+      "versionRange": ">=9.0.0|<10.0.0"
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/invalid-component-version-and-range.xml
+++ b/tools/src/test/resources/1.6/invalid-component-version-and-range.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <components>
+        <component type="library" isExtraneous="false">
+            <name>InvalidVersions</name>
+            <version>9.0.14</version>
+            <versionRange><![CDATA[>=9.0.0|<10.0.0]]></versionRange>
+            <description>may have `version` or `versionRange`, not both. This one does - it is invalid</description>
+        </component>
+    </components>
+</bom>

--- a/tools/src/test/resources/1.6/invalid-component-versionRange-non-extraneous-explicit.json
+++ b/tools/src/test/resources/1.6/invalid-component-versionRange-non-extraneous-explicit.json
@@ -1,0 +1,15 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "InvalidVersions",
+      "description": "versionRange may only exist on extraneous components, set `isExtraneous` explicit",
+      "isExtraneous": false,
+      "versionRange": ">=9.0.0|<10.0.0"
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/invalid-component-versionRange-non-extraneous-implicit.json
+++ b/tools/src/test/resources/1.6/invalid-component-versionRange-non-extraneous-implicit.json
@@ -1,0 +1,14 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "InvalidVersions",
+      "description": "versionRange may only exist on extraneous components, set `isExtraneous` implicit by default value",
+      "versionRange": ">=9.0.0|<10.0.0"
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/valid-component-extraneous-no-version-information.json
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-no-version-information.json
@@ -1,0 +1,14 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "Foo",
+      "description": "extraneous without any version constraints",
+      "isExtraneous": true
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/valid-component-extraneous-no-version-information.xml
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-no-version-information.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <components>
+        <component type="library" isExtraneous="true">
+            <name>Foo</name>
+            <description>extraneous without any version constraints</description>
+        </component>
+    </components>
+</bom>

--- a/tools/src/test/resources/1.6/valid-component-extraneous-with-version.json
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-with-version.json
@@ -1,0 +1,15 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "Foo",
+      "description": "extraneous with version constraint",
+      "isExtraneous": true,
+      "version": "9.1.24"
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/valid-component-extraneous-with-version.xml
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-with-version.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <components>
+        <component type="library" isExtraneous="true">
+            <name>Foo</name>
+            <version>9.1.24</version>
+            <description>extraneous with version constraint</description>
+        </component>
+    </components>
+</bom>

--- a/tools/src/test/resources/1.6/valid-component-extraneous-with-versionRange.json
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-with-versionRange.json
@@ -1,0 +1,15 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "Foo",
+      "description": "extraneous with version range constraints",
+      "isExtraneous": true,
+      "versionRange": ">=9.0.0|<10.0.0"
+    }
+  ]
+}

--- a/tools/src/test/resources/1.6/valid-component-extraneous-with-versionRange.xml
+++ b/tools/src/test/resources/1.6/valid-component-extraneous-with-versionRange.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1"
+>
+    <components>
+        <component type="library" isExtraneous="true">
+            <name>Foo</name>
+            <versionRange><![CDATA[>=9.0.0|<10.0.0]]></versionRange>
+            <description>extraneous with version range constraints</description>
+        </component>
+    </components>
+</bom>


### PR DESCRIPTION
Sketch/proposal for  #321

implementing with `components`, because the objects referenced/required are actually used at runtime and therefore are considered a "component". 



- [x] sketch JSON schema  
  - properties and assert
  - test cases 
- [x] sketch XML schema
  - properties. assert would require XSD1.1 which is not broadly implemented, yet.
  - test cases
- [ ] sketch ProtoBuff schema  
  SKIPPED THIS FOR NOW as I do not have a lot of practice with PB schema
  Please help :-) 

