### PR TITLE
CBOM: adds 'parameterSetIdentifier' property, replacing 'variant'

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -3879,15 +3879,10 @@
                 "unknown"
               ]
             },
-            "variant": {
+            "parameterSetIdentifier": {
               "type": "string",
-              "title": "variant",
-              "description": "The variant for the crypto algorithm, algorithm components should be delimited with '-'",
-              "examples": [
-                "aes128-cbc-pkcs7",
-                "rsa2048-cbc-oaep-sha256-mgf1",
-                "kyber1024"
-              ]
+              "title": "parameter set identifier",
+              "description": "An identifier for the parameter set of the crypto algorithm. Exampes: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
             },
             "curve": {
               "type": "string",


### PR DESCRIPTION
The new property 'parameterSetIdentifier' replaces 'variant' and contains information about the parameter set identifying an algorithm. This can be, for example, the key length (in AES), the digest length (in SHA2), or the hash algorithm used internally (in SLH-DSA / FIPS205). The "description" field contains some examples.

This PR is motivated by https://github.com/IBM/CBOM/issues/37 and intends to address its use case.

Tagging @stevespringett, @n1ckl0sk0rtge, @mrutkows, @GeroDittmann