### PR TITLE
Support for hybrids/combiners: add 'combiner' as primitive

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -3880,7 +3880,7 @@
             "primitive": {
               "type": "string",
               "title": "primitive",
-              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algoorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM) and authenticated encryption (ae, e.g. AES-GCM).",
+              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algoorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
               "enum": [
                 "drbg",
                 "mac",
@@ -3894,6 +3894,7 @@
                 "keyagree",
                 "kem",
                 "ae",
+                "combiner",
                 "other",
                 "unknown"
               ]


### PR DESCRIPTION
Adds 'combiner' as enum entry in 'primitive'.

Addresses the use case when combinations of (e.g.) classical crypto like RSA is used together with QSC like Dilithium. An entry of this primitive allows to express the combiner used. Adding dependencies to RSA/Dilithium then allows to express the algorithms used in the combiner. Note: "combiners" are also known as "hybrids", but this term can be ambiguous so I prefer the term combiner.