### PR TITLE
fix: correcting title of `attestations[].map[].counterClaim`

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -178,7 +178,7 @@
                     },
                     "counterClaims": {
                       "type": "array",
-                      "title": "Claims",
+                      "title": "Counter Claims",
                       "description": "The list of  `bom-ref` to the counter claims being attested to.",
                       "items": { "$ref": "#/definitions/refLinkType" }
                     },


### PR DESCRIPTION
Fixes #373 which addresses a small typo in the `counterClaim` field title in the Attestation 1.6