### PR TITLE
fix/harmonize version length

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -2912,7 +2912,6 @@
     "version": {
       "description": "A single disjunctive version identifier, for a component or service.",
       "type": "string",
-      "minLength": 1,
       "maxLength": 1024,
       "examples": [
         "9.0.14",

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -69,7 +69,9 @@ limitations under the License.
             ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:restriction base="xs:normalizedString"/>
+        <xs:restriction base="xs:normalizedString">
+            <xs:maxLength value="1024"/>
+        </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="versionRangeType">
         <xs:annotation>


### PR DESCRIPTION
Harmonize/fix  the version constraints between XML and JSON.
as pointed out here https://github.com/CycloneDX/specification/pull/323/files#r1541002916


old:
- JSON version was string minLen 1 and maxLen 1024
- XML version was string minLen 0 and maxLen infinity

new:
- XML and JSON version are string minLen 0 and maxLen 1024
