### PR TITLE
tests: annotate schema for test resources of CDX1.6 JSON

### DIFF
--- a/tools/src/test/resources/1.6/invalid-bomformat-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-bomformat-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "AnotherFormat",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-component-ref-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-component-ref-1.6.json
@@ -1,15 +1,10 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "version": 1,
   "components": [
-    {
-      "type": "library",
-      "bom-ref": "123",
-      "name": "acme-library",
-      "version": "1.0.0"
-    },
     {
       "type": "library",
       "bom-ref": "123",

--- a/tools/src/test/resources/1.6/invalid-component-ref-1.6.xml
+++ b/tools/src/test/resources/1.6/invalid-component-ref-1.6.xml
@@ -10,6 +10,10 @@
                     <name>acme-library</name>
                     <version>1.0.0</version>
                 </component>
+                <component type="library" bom-ref="123">
+                    <name>acme-library2</name>
+                    <version>1.0.0</version>
+                </component>
                 <component type="library" bom-ref="">
                     <!-- empty value in attribute `bom-ref` -->
                     <name>acme-library</name>

--- a/tools/src/test/resources/1.6/invalid-component-swid-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-component-swid-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-component-type-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-component-type-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-dependency-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-dependency-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-empty-component-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-empty-component-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-hash-alg-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-hash-alg-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-hash-md5-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-hash-md5-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-hash-sha1-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-hash-sha1-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-hash-sha256-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-hash-sha256-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-hash-sha512-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-hash-sha512-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-issue-type-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-issue-type-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-license-choice-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-license-choice-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-license-encoding-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-license-encoding-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-license-id-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-license-id-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-license-missing-id-and-name-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-license-missing-id-and-name-1.6.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "version": 1,
   "components": [
     {
+      "type": "library",
       "name": "license-with-no-id-nor-name",
       "version": "23",
       "description": "testcase for issue#288",

--- a/tools/src/test/resources/1.6/invalid-metadata-license-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-metadata-license-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-metadata-timestamp-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-metadata-timestamp-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-missing-component-type-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-missing-component-type-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-patch-type-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-patch-type-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-properties-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-properties-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:bcb403ae-91fa-436e-bc93-84d1078cdeed",

--- a/tools/src/test/resources/1.6/invalid-scope-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-scope-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/invalid-serialnumber-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-serialnumber-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f",

--- a/tools/src/test/resources/1.6/invalid-service-data-1.6.json
+++ b/tools/src/test/resources/1.6/invalid-service-data-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-annotation-1.6.json
+++ b/tools/src/test/resources/1.6/valid-annotation-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-assembly-1.6.json
+++ b/tools/src/test/resources/1.6/valid-assembly-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-attestation-1.6.json
+++ b/tools/src/test/resources/1.6/valid-attestation-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-bom-1.6.json
+++ b/tools/src/test/resources/1.6/valid-bom-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-hashes-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-hashes-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-identifiers-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-identifiers-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-ref-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-ref-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-swid-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-swid-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-swid-full-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-swid-full-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-component-types-1.6.json
+++ b/tools/src/test/resources/1.6/valid-component-types-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-compositions-1.6.json
+++ b/tools/src/test/resources/1.6/valid-compositions-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-cryptography-full-1.6.json
+++ b/tools/src/test/resources/1.6/valid-cryptography-full-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-cryptography-implementation-1.6.json
+++ b/tools/src/test/resources/1.6/valid-cryptography-implementation-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-dependency-1.6.json
+++ b/tools/src/test/resources/1.6/valid-dependency-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-empty-components-1.6.json
+++ b/tools/src/test/resources/1.6/valid-empty-components-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-evidence-1.6.json
+++ b/tools/src/test/resources/1.6/valid-evidence-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-external-reference-1.6.json
+++ b/tools/src/test/resources/1.6/valid-external-reference-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-formulation-1.6.json
+++ b/tools/src/test/resources/1.6/valid-formulation-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-license-expression-1.6.json
+++ b/tools/src/test/resources/1.6/valid-license-expression-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-license-id-1.6.json
+++ b/tools/src/test/resources/1.6/valid-license-id-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-license-licensing-1.6.json
+++ b/tools/src/test/resources/1.6/valid-license-licensing-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-license-name-1.6.json
+++ b/tools/src/test/resources/1.6/valid-license-name-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-machine-learning-1.6.json
+++ b/tools/src/test/resources/1.6/valid-machine-learning-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-machine-learning-considerations-env-1.6.json
+++ b/tools/src/test/resources/1.6/valid-machine-learning-considerations-env-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:ed5c5ba0-2be6-4b58-ac29-01a7fd375123",

--- a/tools/src/test/resources/1.6/valid-metadata-author-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-author-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-license-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-license-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-lifecycle-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-lifecycle-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-manufacture-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-manufacture-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-manufacturer-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-manufacturer-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-supplier-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-supplier-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-timestamp-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-timestamp-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-tool-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-tool-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-metadata-tool-deprecated-1.6.json
+++ b/tools/src/test/resources/1.6/valid-metadata-tool-deprecated-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-minimal-viable-1.6.json
+++ b/tools/src/test/resources/1.6/valid-minimal-viable-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-patch-1.6.json
+++ b/tools/src/test/resources/1.6/valid-patch-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-properties-1.6.json
+++ b/tools/src/test/resources/1.6/valid-properties-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-release-notes-1.6.json
+++ b/tools/src/test/resources/1.6/valid-release-notes-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-saasbom-1.6.json
+++ b/tools/src/test/resources/1.6/valid-saasbom-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-service-1.6.json
+++ b/tools/src/test/resources/1.6/valid-service-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-service-empty-objects-1.6.json
+++ b/tools/src/test/resources/1.6/valid-service-empty-objects-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-signatures-1.6.json
+++ b/tools/src/test/resources/1.6/valid-signatures-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-standard-1.6.json
+++ b/tools/src/test/resources/1.6/valid-standard-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-tags-1.6.json
+++ b/tools/src/test/resources/1.6/valid-tags-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/tools/src/test/resources/1.6/valid-vulnerability-1.6.json
+++ b/tools/src/test/resources/1.6/valid-vulnerability-1.6.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",


### PR DESCRIPTION
fixes: #254
followup of: #403
supersedes: #255



finally! IDE support for editing the JSON test resources.
not added in for schema <1.6 for reasons as described in #403