### PR TITLE
chore(dependencies): bump bufbuild/buf:1.30.1

### DIFF
--- a/tools/src/test/proto/test.sh
+++ b/tools/src/test/proto/test.sh
@@ -10,7 +10,7 @@ TEST_RES_DIR='tools/src/test/resources'
 
 REMOTE="https://github.com/${GITHUB_REPOSITORY:-CycloneDX/specification}.git"
 
-BUF_IMAGE_VERSION='1.30.0'
+BUF_IMAGE_VERSION='1.30.1'
 
 
 ## ----


### PR DESCRIPTION
https://github.com/bufbuild/buf/releases/tag/v1.30.1

> Fix issue where `buf lint` incorrectly reports an error for `(buf.validate.field).repeated`
is set for a repeated validation rule.