### PR TITLE
tests: Adding 1.6 valid and invalid test files in the Java tests

### DIFF
--- a/tools/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
@@ -29,6 +29,7 @@ public abstract class BaseSchemaVerificationTest {
         files.addAll(getResources("1.3/"));
         files.addAll(getResources("1.4/"));
         files.addAll(getResources("1.5/"));
+        files.addAll(getResources("1.6/"));
         return files;
     }
 

--- a/tools/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
@@ -43,6 +43,8 @@ public class JsonSchemaVerificationTest extends BaseSchemaVerificationTest {
                     schemaVersion = Version.VERSION_14;
                 } else if (file.endsWith("-1.5.json")) {
                     schemaVersion = Version.VERSION_15;
+                } else if (file.endsWith("-1.6.json")) {
+                    schemaVersion = Version.VERSION_16;
                 } else {
                     schemaVersion = null;
                 }

--- a/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
@@ -53,6 +53,8 @@ public class XmlSchemaVerificationTest extends BaseSchemaVerificationTest {
                     schemaVersion = Version.VERSION_14;
                 } else if (file.endsWith("-1.5.xml")) {
                     schemaVersion = Version.VERSION_15;
+                } else if (file.endsWith("-1.6.xml")) {
+                    schemaVersion = Version.VERSION_16;
                 } else {
                     schemaVersion = null;
                 }


### PR DESCRIPTION
See related PRs: #480 (and #479).

See below the Java tests seems to run okay:

![XML_JSON_1 6_tests_20240613_113532](https://github.com/CycloneDX/specification/assets/102670102/a88687bb-9d53-4762-8dbe-d8d730d2c178)
