### PR TITLE
docs: revisit example urls in spec 1.6

### DIFF
--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -355,7 +355,10 @@ limitations under the License.
             </xs:element>
             <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                    <xs:documentation>The URL of the organization. Multiple URLs are allowed.</xs:documentation>
+                    <xs:documentation>
+                        The URL of the organization. Multiple URLs are allowed.
+                        Example: https://example.com
+                    </xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="contact" type="bom:organizationalContact" minOccurs="0" maxOccurs="unbounded">
@@ -1385,8 +1388,11 @@ limitations under the License.
             </xs:enumeration>
             <xs:enumeration value="license">
                 <xs:annotation>
-                    <xs:documentation>The URL to the license file. If a license URL has been defined in the license
-                        node, it should also be defined as an external reference for completeness</xs:documentation>
+                    <xs:documentation>
+                        The URL to the license file. If a license URL has been defined in the license
+                        node, it should also be defined as an external reference for completeness.
+                        Example: https://www.apache.org/licenses/LICENSE-2.0.txt
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="build-meta">


### PR DESCRIPTION
closes #452

revisited all `https?://` in the current spec. no example domain was used, except the intended `example.com`.
streamlined JSON and XML.

