### PR TITLE
Add space after colon

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -5466,7 +5466,7 @@
             },
             "size": {
                 "type": "integer",
-                "title":"Size",
+                "title": "Size",
                 "description": "The size of the cryptographic asset (in bits)."
             },
             "format": {


### PR DESCRIPTION
When trying to create a pydantic class from this spec using `datamodel-code-gen`, having a quote right after a colon creates the following error: https://stackoverflow.com/questions/9055371/python-and-pyaml-yaml-scanner-scannererror-mapping-values-are-not-allowed-her

Adding a space to make this processable by datamodel-code-gen