### PR TITLE
docs: allow SchemaDocs HTML generator run for one(specific) CDX version

### DIFF
--- a/docgen/json/gen.sh
+++ b/docgen/json/gen.sh
@@ -5,9 +5,8 @@ THIS_PATH="$(realpath "$(dirname "$0")")"
 SCHEMA_PATH="$(realpath "$THIS_PATH/../../schema")"
 DOCS_PATH="$THIS_PATH/docs"
 TEMPLATES_PATH="$THIS_PATH/templates"
-
-rm -f -R "$DOCS_PATH"
-mkdir -p "$DOCS_PATH/"{1.2,1.3,1.4,1.5,1.6}
+VALID_CYCLONEDX_VERSIONS=(1.2 1.3 1.4 1.5 1.6)
+DRAFT_CYCLONEDX_VERSIONS=()
 
 # Check to see if generate-schema-doc is executable and is in the path. If not, install JSON Schema for Humans.
 if ! [ -x "$(command -v generate-schema-doc)" ]
@@ -16,8 +15,31 @@ then
   pip3 install -r "$THIS_PATH/requirements.txt"
 fi
 
+# Function to check if a version is in an array
+version_in_list() {
+  local version="$1"
+  shift
+  local list=("$@")
+  for item in "${list[@]}"; do
+    if [[ "$item" == "$version" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 generate () {
   version="$1"
+
+  # Check if the version match a valid CycloneDX version or a draft under development
+    if ! version_in_list "$version" "${VALID_CYCLONEDX_VERSIONS[@]}" && ! version_in_list "$version" "${DRAFT_CYCLONEDX_VERSIONS[@]}"; then
+    echo "Failed: wrong CycloneDX version: $version"
+    exit 1
+  fi
+
+  echo "Create folder $DOCS_PATH/$version"
+  mkdir -p "$DOCS_PATH/$version"
+
   title="CycloneDX v${version} JSON Reference"
   echo "Generating: $title"
 
@@ -45,8 +67,37 @@ generate () {
   sed -i -e "s/\${version}/$version/g" "$DOCS_PATH/$version/index.html"
 }
 
-generate 1.2
-generate 1.3
-generate 1.4
-generate 1.5
-generate 1.6
+USAGE_HELP="Generate HTML JSON Schema navigator for CyccloneDX
+Usage: $0 <version> : runs only for <version>
+       $0           : loops over all valid and draft CycloneDX versions"
+
+# Main logic to handle the argument using a switch case
+case "$#" in
+  0)
+    # No arguments provided: Loop over all VALID_CYCLONEDX_VERSIONS and DRAFT_CYCLONEDX_VERSIONS
+    echo "Deleting folder $DOCS_PATH"
+    rm -f -R "$DOCS_PATH"
+    for version in "${VALID_CYCLONEDX_VERSIONS[@]}" "${DRAFT_CYCLONEDX_VERSIONS[@]}"; do
+      generate "$version"
+    done
+    ;;
+  1)
+    case "$1" in
+      "-h"|"--help")
+        echo "Usage: $USAGE_HELP"
+        exit 1
+        ;;
+      *)
+        # One argument provided: Call generate with the specific version
+        echo "Deleting folder $DOCS_PATH"
+        rm -f -R "$DOCS_PATH"
+        generate "$1"
+        ;;
+    esac
+    ;;
+  *)
+    # More than one argument provided: Show usage help
+    echo "Usage: $USAGE_HELP"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The JSON Schema HTML viewer generator script `docgen/json/gen.sh` supports generating only for one particular CycloneDX version, including the possibility of generating the HTML only for draft version of CycloneDX during dev time.

## Use Case

I want to propose new objects in the CycloneDX Specification. And for checking the JSON Schema, I like to locally use the HTML view to check the content of the JSON Schema.

However, during dev time when I was modifying the JSON Schema, I found it not convenient that the script `docgen/json/gen.sh` regenerate the HTML doc for every version of CycloneDX each time I run it when I only need the version I am working on.

## Proposition

I modified the script `docgen/json/gen.sh` to be able to run `gen.sh` only for a particular version of CycloneDX.

For example: 

```bash
./gen.sh 1.6
```

But I also added a list `DRAFT_CYCLONEDX_VERSIONS` for when I am working on a draft proposition of CycloneDX spec.
For example: 

```bash
# I modify `docgen/json/gen.sh` to add the name of my draft file
DRAFT_CYCLONEDX_VERSIONS=(my_cdx_dev_draft)
```

I create a JSON schema draft file `schema/bom-my_cdx_dev_draft.schema.json`:

Then I run:

```bash
./gen.sh my_cdx_dev_draft
```

Which creates only the HTML for `my_cdx_dev_draft`

```bash
tree docgen/json/docs/my_cdx_dev_draft/
docgen/json/docs/my_cdx_dev_draft/
├── index.html
├── schema_doc.css
└── schema_doc.min.j
```

And in order not to disturb the way `docgen/json/gen.sh` works now, running it without argument generates the HTML for all the CDX versions:

```bash
./gen.sh
```

```bash
ls -1 docgen/json/docs/
1.2
1.3
1.4
1.5
1.6
```

I also added a small usage help message.

```bash
./gen.sh -h
Deleting folder /home/thedetective/Documents/dev-workspace/cyclonedx/cyclonedx-specification.thalesgroup/docgen/json/docs
Usage: Generate HTML JSON Schema navigator for CyccloneDX
Usage: ./gen.sh <version> : runs only for <version>
       ./gen.sh           : loops over all valid and draft CycloneDX versions
```

## What about `docgen/xml/gen.sh` ?

I will probably propose the same kind of modification to the XML `docgen/xml/gen.sh` script to achieve the same results.

## Conclusion

There are probably other way to achieve this result. I think this one is the cheapest in terms of how the `gen.sh` script is modified.