### PR TITLE
XML Schema HTML viewer generator script supports generating for one particular CDX version

### DIFF
--- a/docgen/xml/gen.sh
+++ b/docgen/xml/gen.sh
@@ -5,18 +5,44 @@ THIS_PATH="$(realpath "$(dirname "$0")")"
 SCHEMA_PATH="$(realpath "$THIS_PATH/../../schema")"
 DOCS_PATH="$THIS_PATH/docs"
 
+VALID_CYCLONEDX_VERSIONS=(1.0 1.1 1.2 1.3 1.4 1.5 1.6)
+DRAFT_CYCLONEDX_VERSIONS=()
+
 SAXON_JAR='Saxon-HE-9.9.1-8.jar'
 
-rm -f -R docs
+# Download the Saxon JAR if it doesn't exist
 if [ ! -f "$THIS_PATH/$SAXON_JAR" ]; then
   curl --output-dir "$THIS_PATH" -O \
     "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/9.9.1-8/$SAXON_JAR"
 fi
 
+# Function to check if a version is in an array
+version_in_list() {
+  local version="$1"
+  shift
+  local list=("$@")
+  for item in "${list[@]}"; do
+    if [[ "$item" == "$version" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 generate () {
   version="$1"
+
+  # Check if the version match a valid CycloneDX version or a draft under development
+    if ! version_in_list "$version" "${VALID_CYCLONEDX_VERSIONS[@]}" && ! version_in_list "$version" "${DRAFT_CYCLONEDX_VERSIONS[@]}"; then
+    echo "Failed: wrong CycloneDX version: $version"
+    exit 1
+  fi
+
   title="CycloneDX v$version XML Reference"
   echo "Generating: $title"
+
+  echo "Create folder $DOCS_PATH/$version"
+  mkdir -p "$DOCS_PATH/$version"
 
   java -jar "$THIS_PATH/$SAXON_JAR" \
     -s:"$SCHEMA_PATH/bom-${version}.xsd" \
@@ -26,10 +52,37 @@ generate () {
     title="$title"
 }
 
-generate 1.0
-generate 1.1
-generate 1.2
-generate 1.3
-generate 1.4
-generate 1.5
-generate 1.6
+USAGE_HELP="Generate HTML XML Schema navigator for CyccloneDX
+Usage: $0 <version> : runs only for <version>
+       $0           : loops over all valid and draft CycloneDX versions"
+
+# Main logic to handle the argument using a switch case
+case "$#" in
+  0)
+    # No arguments provided: Loop over all VALID_CYCLONEDX_VERSIONS and DRAFT_CYCLONEDX_VERSIONS
+    echo "Deleting folder $DOCS_PATH"
+    rm -f -R "$DOCS_PATH"
+    for version in "${VALID_CYCLONEDX_VERSIONS[@]}" "${DRAFT_CYCLONEDX_VERSIONS[@]}"; do
+      generate "$version"
+    done
+    ;;
+  1)
+    case "$1" in
+      "-h"|"--help")
+        echo "Usage: $USAGE_HELP"
+        exit 1
+        ;;
+      *)
+        # One argument provided: Call generate with the specific version
+        echo "Deleting folder $DOCS_PATH"
+        rm -f -R "$DOCS_PATH"
+        generate "$1"
+        ;;
+    esac
+    ;;
+  *)
+    # More than one argument provided: Show usage help
+    echo "Usage: $USAGE_HELP"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The XML Schema HTML viewer generator script `docgen/xml/gen.sh` supports generating only for one particular CycloneDX version, including the possibility of generating the HTML only for draft version of CycloneDX during dev time.

See also a similar PR for JSON: https://github.com/CycloneDX/specification/pull/507

## Use Case

I want to propose new objects in the CycloneDX Specification. And for checking the XML XSD Schema, I like to locally use the HTML view to check the content of the XSD.

However, I found it not convenient that the script `docgen/xml/gen.sh` regenerate the HTML doc for every version of CycloneDX each time I run it when I only need the version I am working on.

## Proposition

I modified the script `docgen/xml/gen.sh` to be able to run `gen.sh` only for a particular version of CycloneDX.

For example: 

```bash
./gen.sh 1.6
```

But I also added a list `DRAFT_CYCLONEDX_VERSIONS` for when I am working on a draft proposition of CycloneDX spec.
For example: 

```bash
# I modify `docgen/xml/gen.sh` to add the name of my draft file
DRAFT_CYCLONEDX_VERSIONS=(my_cdx_dev_draft)
```

I create a JSON schema draft file `schema/bom-my_cdx_dev_draft.xsd`:

Then I run:

```bash
./gen.sh my_cdx_dev_draft
```

Which creates only the HTML for `my_cdx_dev_draft`

```bash
tree docgen/xml/
docgen/xml/
├── docs
│   └── 1.6
│       └── index.html
├── gen.sh
├── Saxon-HE-9.9.1-8.jar
└── xs3p.xsl
```

And in order not to disturb the way `docgen/xml/gen.sh` works now, running it without argument generates the HTML for all the CDX versions:

```bash
./gen.sh
```

```bash
ls -1 docgen/xml/docs/
1.0
1.1
1.2
1.3
1.4
1.5
1.6
```

I also added a small usage help message.

```bash
./gen.sh -h
Usage: Generate HTML XML Schema navigator for CyccloneDX
Usage: ./gen.sh <version> : runs only for <version>
       ./gen.sh           : loops over all valid and draft CycloneDX versions
```

## Conclusion

There are probably other way to achieve this result. I think this one is the cheapest in terms of how the `gen.sh` script is modified.