### PR TITLE
fix(ProtoBuff): component evidence should be optional, istead of repeated

### DIFF
--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -133,7 +133,7 @@ message Component {
   repeated Component components = 21;
   // Specifies optional, custom, properties
   repeated Property properties = 22;
-  // Specifies optional license and copyright evidence
+  // Specifies optional license and copyright evidence. Only the first item in the optional repeated list is to be taken into account; every other item in the list is to be ignored/omitted.
   repeated Evidence evidence = 23;
   // Specifies optional release notes.
   optional ReleaseNotes releaseNotes = 24;


### PR DESCRIPTION
non-breaking fix of #422 
in contrast to #425 
