### PR TITLE
tests: fix ProtoBuf breaking detection to be wire-only

### DIFF
--- a/tools/src/test/proto/buf_breaking-remote.yaml
+++ b/tools/src/test/proto/buf_breaking-remote.yaml
@@ -3,5 +3,4 @@
 version: v1
 breaking:  # https://buf.build/docs/configuration/v1/buf-yaml#breaking
   use:  # see https://buf.build/docs/breaking/overview#rules-and-categories
-    - FILE
     - WIRE_JSON

--- a/tools/src/test/proto/buf_breaking-version.yaml
+++ b/tools/src/test/proto/buf_breaking-version.yaml
@@ -3,7 +3,6 @@
 version: v1
 breaking:  # https://buf.build/docs/configuration/v1/buf-yaml#breaking
   use:  # see https://buf.build/docs/breaking/overview#rules-and-categories
-    - FILE
     - WIRE_JSON
   except:
     # scope is to detect changes from one version to the other -> so ignore "FILE_SAME_PACKAGE"


### PR DESCRIPTION
out spec describes how data models look in data transfers.
current protobuf breaking detection adheres this.

the protobuf breaking detection also does unnecessary detections, which should not matter for our domain.
they are removed, here.