### PR TITLE
fix(xml): requirement descriptions should be unbounded

### DIFF
--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -8027,7 +8027,7 @@ limitations under the License.
                                         </xs:annotation>
                                         <xs:complexType>
                                             <xs:sequence>
-                                                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                                                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>


### PR DESCRIPTION
fixes #528 

where occurrences of `definitions.standards.requirements.descriptions` should be unbounded