### PR TITLE
fix(ProtoBuf): `Component.evidence` optional

### DIFF
--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -133,8 +133,8 @@ message Component {
   repeated Component components = 21;
   // Specifies optional, custom, properties
   repeated Property properties = 22;
-  // Specifies optional license and copyright evidence. Only the first item in the optional repeated list is to be taken into account; every other item in the list is to be ignored/omitted.
-  repeated Evidence evidence = 23;
+  // Specifies optional license and copyright evidence.
+  optional Evidence evidence = 23;
   // Specifies optional release notes.
   optional ReleaseNotes releaseNotes = 24;
   // A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.


### PR DESCRIPTION
fixes #422 
by reverting the unreleased https://github.com/CycloneDX/specification/commit/19a153072690dfb2e8475ea3fa2e09a657d0cef6  & https://github.com/CycloneDX/specification/commit/acc5f3a003f26a6f165d83e5f4f7706546ccc055
as discussed here: https://github.com/CycloneDX/specification/issues/422#issuecomment-2454961082 