### PR TITLE
docs: transfer specdocs to XML 1.6

### DIFF
--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -572,6 +572,9 @@ limitations under the License.
                 </xs:annotation>
             </xs:element>
             <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The hashes of the component.</xs:documentation>
+                </xs:annotation>
                 <xs:complexType>
                     <xs:sequence minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="hash" type="bom:hashType"/>
@@ -1842,6 +1845,12 @@ limitations under the License.
                 </xs:complexType>
             </xs:element>
             <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        A collection of URL's for reference. Multiple URLs are allowed.
+                        Example: "https://example.com"
+                    </xs:documentation>
+                </xs:annotation>
                 <xs:complexType>
                     <xs:sequence minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="url" type="xs:anyURI"/>
@@ -2058,6 +2067,12 @@ limitations under the License.
                 </xs:annotation>
             </xs:element>
             <xs:element name="endpoints" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The endpoint URIs of the service. Multiple endpoints are allowed.
+                        Example: "https://example.com/api/v1/ticker"
+                    </xs:documentation>
+                </xs:annotation>
                 <xs:complexType>
                     <xs:sequence minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="endpoint" type="xs:anyURI" minOccurs="1">
@@ -2088,6 +2103,9 @@ limitations under the License.
                 </xs:annotation>
             </xs:element>
             <xs:element name="data" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies information about the data including the directional flow of data and the data classification.</xs:documentation>
+                </xs:annotation>
                 <xs:complexType>
                     <xs:choice>
                         <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -2253,10 +2271,28 @@ limitations under the License.
                 states that the direction is not known.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:enumeration value="inbound"/>
-            <xs:enumeration value="outbound"/>
-            <xs:enumeration value="bi-directional"/>
-            <xs:enumeration value="unknown"/>
+            <xs:enumeration value="inbound">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data that enters a service.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="outbound">
+                <xs:annotation>
+                    <xs:documentation>Data that exits a service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bi-directional">
+                <xs:annotation>
+                    <xs:documentation>Data flows in and out of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The directional flow of data is not known.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 
@@ -2562,6 +2598,11 @@ limitations under the License.
                             <xs:complexType>
                                 <xs:sequence>
                                     <xs:element name="frame" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.
+                                            </xs:documentation>
+                                        </xs:annotation>
                                         <xs:complexType>
                                             <xs:sequence>
                                                 <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="1">
@@ -2628,7 +2669,13 @@ limitations under the License.
                 </xs:complexType>
             </xs:element>
             <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="copyright" type="bom:copyrightsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="bom:copyrightsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        opyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
@@ -2932,13 +2979,13 @@ limitations under the License.
         </xs:anyAttribute>
     </xs:complexType>
 
-   <!--
-   Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and
-   available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json.
-   In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and
-   available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.
-   -->
     <xs:complexType name="modelCardType">
+        <!--
+        Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and
+        available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json.
+        In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and
+        available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.
+        -->
         <xs:annotation>
             <xs:documentation>
                 A model card describes the intended uses of a machine learning model and potential limitations, including
@@ -3014,7 +3061,11 @@ limitations under the License.
                                             <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
                                         </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="dataset" type="bom:componentDataType" minOccurs="0" maxOccurs="1" />
+                                    <xs:element name="dataset" type="bom:componentDataType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Inline Data Information</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
                                 </xs:choice>
                             </xs:complexType>
                         </xs:element>
@@ -4649,13 +4700,41 @@ limitations under the License.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:enumeration value="critical"/>
-            <xs:enumeration value="high"/>
-            <xs:enumeration value="medium"/>
-            <xs:enumeration value="low"/>
-            <xs:enumeration value="info"/>
-            <xs:enumeration value="none"/>
-            <xs:enumeration value="unknown"/>
+            <xs:enumeration value="critical">
+                <xs:annotation>
+                    <xs:documentation>Critical severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="high">
+                <xs:annotation>
+                    <xs:documentation>High severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="medium">
+                <xs:annotation>
+                    <xs:documentation>Medium severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="low">
+                <xs:annotation>
+                    <xs:documentation>Low severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="info">
+                <xs:annotation>
+                    <xs:documentation>Informational warning.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation>None</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The severity is not known</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 
@@ -4852,11 +4931,31 @@ limitations under the License.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:enumeration value="can_not_fix"/>
-            <xs:enumeration value="will_not_fix"/>
-            <xs:enumeration value="update"/>
-            <xs:enumeration value="rollback"/>
-            <xs:enumeration value="workaround_available"/>
+            <xs:enumeration value="can_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Can not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="will_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Will not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="update">
+                <xs:annotation>
+                    <xs:documentation>Update to a different revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rollback">
+                <xs:annotation>
+                    <xs:documentation>Revert to a previous revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="workaround_available">
+                <xs:annotation>
+                    <xs:documentation>There is a workaround available</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 
@@ -4871,9 +4970,21 @@ limitations under the License.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:enumeration value="affected"/>
-            <xs:enumeration value="unaffected"/>
-            <xs:enumeration value="unknown"/>
+            <xs:enumeration value="affected">
+                <xs:annotation>
+                    <xs:documentation>The version is affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unaffected">
+                <xs:annotation>
+                    <xs:documentation>The version is not affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>It is unknown (or unspecified) whether the given version is affected.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 
@@ -7834,6 +7945,12 @@ limitations under the License.
                 </xs:complexType>
             </xs:element>
             <xs:element name="affirmation" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment.
+                        It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.
+                    </xs:documentation>
+                </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="statement" type="xs:string" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
texts were taken from human-readable spec 