### PR TITLE
docs: docsge fix title in `<meta>` elements

### DIFF
--- a/docgen/json/templates/cyclonedx/base.html
+++ b/docgen/json/templates/cyclonedx/base.html
@@ -8,12 +8,12 @@
     <meta charset="UTF-8"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@CycloneDX_Spec"/>
-    <meta name="twitter:title" content="${quotedTitle}"/>
+    <meta name="twitter:title" content="${title}"/>
     <meta name="twitter:image" content="https://cyclonedx.org/images/CycloneDX-Social-Card.png"/>
-    <meta name="twitter:description" content="${quotedTitle}"/>
-    <meta name="description" content="${quotedTitle}"/>
-    <meta property="og:description" content="${quotedTitle}"/>
-    <meta property="og:title" content="${quotedTitle}"/>
+    <meta name="twitter:description" content="${title}"/>
+    <meta name="description" content="${title}"/>
+    <meta property="og:description" content="${title}"/>
+    <meta property="og:title" content="${title}"/>
     <meta property="og:locale" content="en_US"/>
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://cyclonedx.org/images/CycloneDX-Social-Card.png" />

--- a/docgen/proto/templates/html.tmpl
+++ b/docgen/proto/templates/html.tmpl
@@ -12,12 +12,12 @@ https://github.com/pseudomuto/protoc-gen-doc/blob/master/resources/html.tmpl
     <meta charset="UTF-8"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@CycloneDX_Spec"/>
-    <meta name="twitter:title" content="${quotedTitle}"/>
+    <meta name="twitter:title" content="${title}"/>
     <meta name="twitter:image" content="https://cyclonedx.org/images/CycloneDX-Social-Card.png"/>
-    <meta name="twitter:description" content="${quotedTitle}"/>
-    <meta name="description" content="${quotedTitle}"/>
-    <meta property="og:description" content="${quotedTitle}"/>
-    <meta property="og:title" content="${quotedTitle}"/>
+    <meta name="twitter:description" content="${title}"/>
+    <meta name="description" content="${title}"/>
+    <meta property="og:description" content="${title}"/>
+    <meta property="og:title" content="${title}"/>
     <meta property="og:locale" content="en_US"/>
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://cyclonedx.org/images/CycloneDX-Social-Card.png" />


### PR DESCRIPTION
current docsgen result in broken metatags:
```html
    <meta name="twitter:title" content=""CycloneDX v1.6 Protobuf Reference""/>
    <meta name="twitter:image" content="https://cyclonedx.org/images/CycloneDX-Social-Card.png"/>
    <meta name="twitter:description" content=""CycloneDX v1.6 Protobuf Reference""/>
    <meta name="description" content=""CycloneDX v1.6 Protobuf Reference""/>
    <meta property="og:description" content=""CycloneDX v1.6 Protobuf Reference""/>
    <meta property="og:title" content=""CycloneDX v1.6 Protobuf Reference""/>
```

this PR fixes this