### PR TITLE
[DRAFT] scope required may be another version

### DIFF
--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -612,7 +612,7 @@ message Pedigree {
 enum Scope {
   // Default
   SCOPE_UNSPECIFIED = 0;
-  // The component is required for runtime
+  // The component is required for runtime, or another version.
   SCOPE_REQUIRED = 1;
   // The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but, due to configuration or other restrictions, are prohibited from being called must be scoped as 'required'.
   SCOPE_OPTIONAL = 2;

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -938,7 +938,7 @@
             "excluded"
           ],
           "meta:enum": {
-            "required": "The component is required for runtime",
+            "required": "The component is required for runtime, or another version.",
             "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
             "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
           },

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -1010,7 +1010,7 @@ limitations under the License.
         <xs:restriction base="xs:string">
             <xs:enumeration value="required">
                 <xs:annotation>
-                    <xs:documentation>The component is required for runtime</xs:documentation>
+                    <xs:documentation>The component is required for runtime, or another version.</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="optional">


### PR DESCRIPTION
in OBOM use case, component listed at runtime is very precise

in SBOM use case, in many languages or package/dependency managers, when the dependency tree is calculated at build time, components listed at build time may be replaced at runtime by another version "of the same component": this is particularly true with libraries.

This ability to change the version between build time and runtime makes risk evaluation of libraries not accurate.

This PR proposes to explicit this question of version: perhaps the best solution will be create another scope instead, to differentiate this strict version vs loose version