### PR TITLE
chore: introduce PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- 
+Thank you for taking the time to developing and donate a feature or core enhancement.
+
+We would kindly ask you to create pull-requests only for things that were discussed in a ticket, first.
+So please have the related ticket/issue id handy. 
+If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose
+-->
+
+<!-- 
+
+Please write a short desciption of what the pull-requet intends to do and which ticket it fixes/closes.
+
+Examepl:
+>  As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum.
+>
+>  fixes #485
+
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- 
-Thank you for taking the time to develop and contribute a feature or core enhancement!
+Thank you for taking the time to develop and contribute a core enhancement or fix for a defect!
 
-We kindly request that you create pull requests only for issues that have been discussed in a ticket first.
+We kindly request that you create pull requests only for things that have been discussed in a ticket first; exceptions may be made for spelling or grammar fixe.
 Please have the related ticket/issue ID ready. 
 If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,18 @@
 <!-- 
-Thank you for taking the time to developing and donate a feature or core enhancement.
+Thank you for taking the time to develop and contribute a feature or core enhancement!
 
-We would kindly ask you to create pull-requests only for things that were discussed in a ticket, first.
-So please have the related ticket/issue id handy. 
+We kindly request that you create pull requests only for issues that have been discussed in a ticket first.
+Please have the related ticket/issue ID ready. 
 If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose
 -->
 
 <!-- 
 
-Please write a short desciption of what the pull-requet intends to do and which ticket it fixes/closes.
+Please provide a brief description of what this pull request intends to do and which ticket it fixes/closes.
 
-Examepl:
->  As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum.
->
->  fixes #485
+Example: 
+> As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum. 
+> 
+> fixes #485 
 
 -->


### PR DESCRIPTION
when a spec PR pops up without any previous discussion, then this usually disturbs me.

A PR w/o a proper issue means somebody skipped the most relevant part: give people a proper understanding of the "problem" and give them the freedom to think about possible solutions freely. Starting with a solution always narrows the view of everybody, and in almost all cases the proposed solution is not the best one.

to guide pull-requests, i propose the following PR template: https://github.com/CycloneDX/specification/pull/579

What do you think about the situation?
- Should PRs without a ticket exist in our spec-repo?
- What about the wording in the PR template? is it friendly enough to no guide people and not scare them away? 

(Yes, I opened this PR without any discussion/ticket before. Ironic, isn't it? ;-))