### PR TITLE
docs: docsgen latest first

### DIFF
--- a/docgen/json/gen.sh
+++ b/docgen/json/gen.sh
@@ -47,9 +47,9 @@ generate () {
   sed -i -e "s/\${version}/$version/g" "$OUT_FILE"
 }
 
-generate 1.2
-generate 1.3
-generate 1.4
-generate 1.5
-generate 1.6
 generate 1.7
+generate 1.6
+generate 1.5
+generate 1.4
+generate 1.3
+generate 1.2

--- a/docgen/proto/gen.sh
+++ b/docgen/proto/gen.sh
@@ -42,8 +42,8 @@ generate () {
   sed -i -e "s/\${version}/$version/g" "$OUT_DIR/$OUT_FILE"
 }
 
-generate 1.3
-generate 1.4
-generate 1.5
-generate 1.6
 generate 1.7
+generate 1.6
+generate 1.5
+generate 1.4
+generate 1.3

--- a/docgen/xml/gen.sh
+++ b/docgen/xml/gen.sh
@@ -38,11 +38,11 @@ generate () {
     title="$title"
 }
 
-generate 1.0
-generate 1.1
-generate 1.2
-generate 1.3
-generate 1.4
-generate 1.5
-generate 1.6
 generate 1.7
+generate 1.6
+generate 1.5
+generate 1.4
+generate 1.3
+generate 1.2
+generate 1.1
+generate 1.0


### PR DESCRIPTION
We often only need the latest docs, while developing a new version.
Therefore, the latest version's docs are generated first.