### PR TITLE
tests(Java): run test against actual schema files

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -54,8 +54,9 @@
         <lib.commons.io.version>2.17.0</lib.commons.io.version>
         <lib.commons.lang3.version>3.17.0</lib.commons.lang3.version>
         <lib.commons.text.version>1.12.0</lib.commons.text.version>
+        <lib.json.schema.validator>1.5.5</lib.json.schema.validator>
         <lib.unirest.version>1.4.9</lib.unirest.version>
-        <lib.cyclonedx.core.java.version>10.0.0</lib.cyclonedx.core.java.version>
+        <lib.slf4j.api>2.0.16</lib.slf4j.api>
     </properties>
 
     <scm>
@@ -98,6 +99,24 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${lib.slf4j.api}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${lib.slf4j.api}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Apache Commons -->
         <dependency>
@@ -124,15 +143,21 @@
         </dependency>
         <!-- Unit tests -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0</version>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${lib.json.schema.validator}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.cyclonedx</groupId>
-            <artifactId>cyclonedx-core-java</artifactId>
-            <version>${lib.cyclonedx.core.java.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Runtime-only test dependency -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -142,15 +167,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
             </plugin>
         </plugins>
         <testResources>
             <testResource>
-                <directory>${basedir}/../schema</directory>
+                <directory>${project.basedir}/../schema</directory>
             </testResource>
             <testResource>
-                <directory>src/test/resources/</directory>
+                <directory>src/test/resources</directory>
             </testResource>
         </testResources>
     </build>

--- a/tools/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
@@ -33,17 +33,14 @@ public abstract class BaseSchemaVerificationTest {
         return files;
     }
 
-    List<String> getResources(final String resourceDirectory) throws Exception {
-        final List<String> files = new ArrayList<>();
-        String dir = resourceDirectory;
-        if (!resourceDirectory.endsWith("/")) {
-            dir += "/";
-        }
-        try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(dir)) {
+    private List<String> getResources(final String resourceDirectory) throws Exception {
+        final List<String> resources = new ArrayList<>();
+        try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(resourceDirectory)) {
             if (in != null) {
-                files.addAll(IOUtils.readLines(in, StandardCharsets.UTF_8));
+                IOUtils.readLines(in, StandardCharsets.UTF_8)
+                        .forEach(resource -> resources.add(resourceDirectory + resource));
             }
         }
-        return files;
+        return resources;
     }
 }

--- a/tools/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
@@ -13,7 +13,6 @@
  */
 package org.cyclonedx.schema;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,10 +28,12 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.NonValidationKeyword;
 import com.networknt.schema.SchemaId;
+import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.resource.ClasspathSchemaLoader;
+import com.networknt.schema.resource.DisallowSchemaLoader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,6 +44,9 @@ import org.junit.jupiter.api.TestFactory;
 class JsonSchemaVerificationTest extends BaseSchemaVerificationTest {
 
     private static final ObjectMapper MAPPER = new JsonMapper();
+
+    private static final String JSF_NAMESPACE = "http://cyclonedx.org/schema/jsf-0.82.schema.json";
+    private static final String SPDX_NAMESPACE = "http://cyclonedx.org/schema/spdx.schema.json";
 
     private static final JsonSchema VERSION_12;
     private static final JsonSchema VERSION_13;
@@ -62,22 +66,15 @@ class JsonSchemaVerificationTest extends BaseSchemaVerificationTest {
                 .defaultMetaSchemaIri(SchemaId.V7)
                 .metaSchema(addCustomKeywords(JsonMetaSchema.getV7()))
                 .metaSchemaFactory(metaSchemaFactory)
+                .schemaLoaders(b -> b.add(new ClasspathSchemaLoader()).add(DisallowSchemaLoader.getInstance()))
+                .schemaMappers(b -> b.mapPrefix(SPDX_NAMESPACE, "classpath:spdx.schema.json")
+                        .mapPrefix(JSF_NAMESPACE, "classpath:jsf-0.82.schema.json"))
                 .build();
-        ClassLoader cl = JsonSchemaVerificationTest.class.getClassLoader();
-        try {
-            VERSION_12 = factory.getSchema(
-                    requireNonNull(cl.getResource("bom-1.2-strict.schema.json")).toURI());
-            VERSION_13 = factory.getSchema(
-                    requireNonNull(cl.getResource("bom-1.3-strict.schema.json")).toURI());
-            VERSION_14 = factory.getSchema(
-                    requireNonNull(cl.getResource("bom-1.4.schema.json")).toURI());
-            VERSION_15 = factory.getSchema(
-                    requireNonNull(cl.getResource("bom-1.5.schema.json")).toURI());
-            VERSION_16 = factory.getSchema(
-                    requireNonNull(cl.getResource("bom-1.6.schema.json")).toURI());
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException(e);
-        }
+        VERSION_12 = factory.getSchema(SchemaLocation.of("classpath:bom-1.2-strict.schema.json"));
+        VERSION_13 = factory.getSchema(SchemaLocation.of("classpath:bom-1.3-strict.schema.json"));
+        VERSION_14 = factory.getSchema(SchemaLocation.of("classpath:bom-1.4.schema.json"));
+        VERSION_15 = factory.getSchema(SchemaLocation.of("classpath:bom-1.5.schema.json"));
+        VERSION_16 = factory.getSchema(SchemaLocation.of("classpath:bom-1.6.schema.json"));
     }
 
     private static JsonMetaSchema addCustomKeywords(JsonMetaSchema metaSchema) {

--- a/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
@@ -16,13 +16,10 @@ package org.cyclonedx.schema;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.xml.XMLConstants;
-import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -45,36 +42,24 @@ public class XmlSchemaVerificationTest extends BaseSchemaVerificationTest {
     private static final Schema VERSION_16;
 
     static {
-        // Surefire sets a `basedir` system property
-        // Otherwise we assume that the project is in the current working directory (should work in IDEs)
-        Path toolsPath = Paths.get(System.getProperty("basedir", "."));
-        Path schemaPath = toolsPath.resolve("../schema");
-        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        ClassLoader cl = XmlSchemaVerificationTest.class.getClassLoader();
         try {
-            VERSION_10 = factory.newSchema(
-                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.0.xsd"))});
-            VERSION_11 = factory.newSchema(
-                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.1.xsd"))});
-            VERSION_12 = factory.newSchema(
-                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.2.xsd"))});
-            VERSION_13 = factory.newSchema(
-                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.3.xsd"))});
-            VERSION_14 = factory.newSchema(
-                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.4.xsd"))});
-            VERSION_15 = factory.newSchema(new Source[] {
-                spdxSource(), new StreamSource(schemaPath.resolve("bom-1.5.xsd").toFile())
-            });
-            VERSION_16 = factory.newSchema(new Source[] {
-                spdxSource(), new StreamSource(schemaPath.resolve("bom-1.6.xsd").toFile())
-            });
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file");
+            ClassLoader cl = XmlSchemaVerificationTest.class.getClassLoader();
+            // Override the `schemaLocation` property in the file
+            factory.setProperty(
+                    "http://apache.org/xml/properties/schema/external-schemaLocation",
+                    "http://cyclonedx.org/schema/spdx spdx.xsd");
+            VERSION_10 = factory.newSchema(cl.getResource("bom-1.0.xsd"));
+            VERSION_11 = factory.newSchema(cl.getResource("bom-1.1.xsd"));
+            VERSION_12 = factory.newSchema(cl.getResource("bom-1.2.xsd"));
+            VERSION_13 = factory.newSchema(cl.getResource("bom-1.3.xsd"));
+            VERSION_14 = factory.newSchema(cl.getResource("bom-1.4.xsd"));
+            VERSION_15 = factory.newSchema(cl.getResource("bom-1.5.xsd"));
+            VERSION_16 = factory.newSchema(cl.getResource("bom-1.6.xsd"));
         } catch (SAXException e) {
             throw new IllegalStateException(e);
         }
-    }
-
-    private static Source spdxSource() {
-        return new StreamSource(XmlSchemaVerificationTest.class.getClassLoader().getResourceAsStream("spdx.xsd"));
     }
 
     /**

--- a/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
+++ b/tools/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
@@ -13,57 +13,92 @@
  */
 package org.cyclonedx.schema;
 
-import java.io.File;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.cyclonedx.parsers.XmlParser;
-import org.cyclonedx.Version;
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 public class XmlSchemaVerificationTest extends BaseSchemaVerificationTest {
 
-    @TestFactory
+    private static final Schema VERSION_10;
+    private static final Schema VERSION_11;
+    private static final Schema VERSION_12;
+    private static final Schema VERSION_13;
+    private static final Schema VERSION_14;
+    private static final Schema VERSION_15;
+    private static final Schema VERSION_16;
+
+    static {
+        // Surefire sets a `basedir` system property
+        // Otherwise we assume that the project is in the current working directory (should work in IDEs)
+        Path toolsPath = Paths.get(System.getProperty("basedir", "."));
+        Path schemaPath = toolsPath.resolve("../schema");
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        ClassLoader cl = XmlSchemaVerificationTest.class.getClassLoader();
+        try {
+            VERSION_10 = factory.newSchema(
+                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.0.xsd"))});
+            VERSION_11 = factory.newSchema(
+                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.1.xsd"))});
+            VERSION_12 = factory.newSchema(
+                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.2.xsd"))});
+            VERSION_13 = factory.newSchema(
+                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.3.xsd"))});
+            VERSION_14 = factory.newSchema(
+                    new Source[] {spdxSource(), new StreamSource(cl.getResourceAsStream("bom-1.4.xsd"))});
+            VERSION_15 = factory.newSchema(new Source[] {
+                spdxSource(), new StreamSource(schemaPath.resolve("bom-1.5.xsd").toFile())
+            });
+            VERSION_16 = factory.newSchema(new Source[] {
+                spdxSource(), new StreamSource(schemaPath.resolve("bom-1.6.xsd").toFile())
+            });
+        } catch (SAXException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Source spdxSource() {
+        return new StreamSource(XmlSchemaVerificationTest.class.getClassLoader().getResourceAsStream("spdx.xsd"));
+    }
+
     /**
      * Generates a collection of dynamic tests based on the available XML files.
      *
      * @return Collection<DynamicTest> a collection of dynamic tests
      * @throws Exception if an error occurs during the generation of the dynamic tests
      */
+    @TestFactory
     Collection<DynamicTest> dynamicTestsWithCollection() throws Exception {
-        final List<String> files = getAllResources();
+        final List<String> resources = getAllResources();
         final List<DynamicTest> dynamicTests = new ArrayList<>();
-        for (final String file: files) {
-            if (file.endsWith(".xml")) {
-                final Version schemaVersion;
-                if (file.endsWith("-1.0.xml")) {
-                    schemaVersion = Version.VERSION_10;
-                } else if (file.endsWith("-1.1.xml")) {
-                    schemaVersion = Version.VERSION_11;
-                } else if (file.endsWith("-1.2.xml")) {
-                    schemaVersion = Version.VERSION_12;
-                } else if (file.endsWith("-1.3.xml")) {
-                    schemaVersion = Version.VERSION_13;
-                } else if (file.endsWith("-1.4.xml")) {
-                    schemaVersion = Version.VERSION_14;
-                } else if (file.endsWith("-1.5.xml")) {
-                    schemaVersion = Version.VERSION_15;
-                } else if (file.endsWith("-1.6.xml")) {
-                    schemaVersion = Version.VERSION_16;
-                } else {
-                    schemaVersion = null;
-                }
-                if (file.startsWith("valid") && schemaVersion != null) {
-                    dynamicTests.add(DynamicTest.dynamicTest(file, () -> assertTrue(
-                            isValid(schemaVersion, "/" + schemaVersion.getVersionString() + "/" + file), file)));
-                } else if (file.startsWith("invalid") && schemaVersion != null) {
-                    dynamicTests.add(DynamicTest.dynamicTest(file, () -> assertFalse(
-                            isValid(schemaVersion, "/" + schemaVersion.getVersionString() + "/" + file), file)));
+        for (final String resource : resources) {
+            String resourceName = StringUtils.substringAfterLast(resource, "/");
+            if (resourceName.endsWith(".xml")) {
+                Schema schema = getSchema(resourceName);
+                if (schema != null) {
+                    if (resourceName.startsWith("valid")) {
+                        dynamicTests.add(DynamicTest.dynamicTest(
+                                resource, () -> assertTrue(isValid(schema, resource), resource)));
+                    } else if (resourceName.startsWith("invalid")) {
+                        dynamicTests.add(DynamicTest.dynamicTest(
+                                resource, () -> assertFalse(isValid(schema, resource), resource)));
+                    }
                 }
             }
         }
@@ -73,14 +108,59 @@ public class XmlSchemaVerificationTest extends BaseSchemaVerificationTest {
     /**
      * Validates the given XML file against the specified CycloneDX schema version.
      *
-     * @param  version   the CycloneDX schema version to validate against
-     * @param  resource  the path to the XML file to be validated
+     * @param schema  the CycloneDX schema to validate against
+     * @param resource the path to the XML file to be validated
      * @return boolean   true if the XML file is valid according to the specified schema version, false otherwise
      * @throws Exception if an error occurs during the validation process
      */
-    private boolean isValid(Version version, String resource) throws Exception {
-        final File file = new File(this.getClass().getResource(resource).getFile());
-        final XmlParser parser = new XmlParser();
-        return parser.isValid(file, version);
+    private boolean isValid(Schema schema, String resource) throws Exception {
+        Validator validator = schema.newValidator();
+        validator.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void warning(SAXParseException exception) throws SAXException {
+                throw exception;
+            }
+
+            @Override
+            public void error(SAXParseException exception) throws SAXException {
+                throw exception;
+            }
+
+            @Override
+            public void fatalError(SAXParseException exception) throws SAXException {
+                throw exception;
+            }
+        });
+        try {
+            validator.validate(new StreamSource(getClass().getClassLoader().getResourceAsStream(resource)));
+        } catch (SAXParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private Schema getSchema(String resourceName) {
+        if (resourceName.endsWith("-1.0.xml")) {
+            return VERSION_10;
+        }
+        if (resourceName.endsWith("-1.1.xml")) {
+            return VERSION_11;
+        }
+        if (resourceName.endsWith("-1.2.xml")) {
+            return VERSION_12;
+        }
+        if (resourceName.endsWith("-1.3.xml")) {
+            return VERSION_13;
+        }
+        if (resourceName.endsWith("-1.4.xml")) {
+            return VERSION_14;
+        }
+        if (resourceName.endsWith("-1.5.xml")) {
+            return VERSION_15;
+        }
+        if (resourceName.endsWith("-1.6.xml")) {
+            return VERSION_16;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This change modifies the Java Unit tests to use the schemas in this repository to validate the examples, instead of those bundled in the `cyclonedx-java-core` artifact.

Closes #256

