### PR TITLE
Fix missing type definitions for ComponentData subelements in XML

### DIFF
--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -3931,7 +3931,7 @@ limitations under the License.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="sensitiveData" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="sensitiveData" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
                         A description of any sensitive data in a dataset.
@@ -4020,7 +4020,7 @@ limitations under the License.
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="description" minOccurs="0" maxOccurs="1">
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         A description of this collection of graphics.


### PR DESCRIPTION
<!-- 
Thank you for taking the time to develop and contribute a core enhancement or fix for a defect!

We kindly request that you create pull requests only for things that have been discussed in a ticket first; exceptions may be made for spelling or grammar fixes.
Read more about the process here: https://cyclonedx.org/participate/standardization-process/#working-model

Please have the related ticket/issue ID ready. 
If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose

-->

<!-- 

Please provide a brief description of what this pull request intends to do and which ticket it fixes/closes.  
Example: 
> As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum.
>
> fixes #485 

In case this is for a spelling or grammar improvement, please provide a brief description.
Example:
> Fixe typo: color(AE) -> colour(BE)

-->
Fix missing type definitions for ComponentData subelements

Fixes #600 