### PR TITLE
feat: Add support for TLP marking in metadata (fixes #595)

### DIFF
--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -514,6 +514,8 @@ message Metadata {
   repeated Lifecycles lifecycles = 9;
   // The organization that created the BOM. Manufacturer is common in BOMs created through automated processes. BOMs created through manual means may have '.authors' instead.
   optional OrganizationalEntity manufacturer = 10;
+  // The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the component that the BOM describes.
+  optional Tlp distribution = 11;
 }
 
 message Lifecycles {
@@ -674,6 +676,20 @@ message Swid {
   // The URL to the SWID file.
   optional string url = 7;
 }
+
+enum Tlp {
+  // Default
+  CLEAR = 0;
+  // Limited distribution but can be shared within a community.
+  GREEN = 1;
+  // Limited distribution but can be shared within an organization and with clients
+  AMBER = 2;
+  // Limited distribution but can be shared within an organization.
+  AMBER+STRICT = 3;
+  // Restricted distribution to individual recipients and must not be shared.
+  RED = 4;
+}
+
 
 // Specifies a tool (manual or automated).
 message Tool {

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -712,7 +712,31 @@
           "title": "Properties",
           "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {"$ref": "#/definitions/property"}
+        },
+        "distribution": {
+          "title": "Distribution",
+          "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the component that the BOM describes.",
+          "$ref": "#/definitions/tlpClassification"
         }
+      }
+    },
+    "tlpClassification": {
+      "type" : "string",
+      "title": "Traffic Light Protocol (TLP) Classification",
+      "description": "The Traffic Light Protocol (TLP) classification for the component that the BOM describes. TLP is a classification system for identifying the potential risk associated with artefact, including whether it is subject to certain types of legal, financial, or technical threats. Refer to [https://www.first.org/tlp/](https://www.first.org/tlp/) for further information. The default classification is CLEAR",
+      "enum": [
+        "AMBER",
+        "AMBER+STRICT",
+        "GREEN",
+        "RED",
+        "CLEAR"
+      ],
+      "meta:enum": {
+        "AMBER": "The BOM is subject to limited disclosure, and recipients can only share the BOM on a need-to-know basis within their organization and with clients.",
+        "AMBER+STRICT": "The BOM is subject to limited disclosure, and recipients can only share the BOM on a need-to-know basis within their organization.",
+        "GREEN": "The BOM is subject to limited disclosure, and recipients can share the BOM within their community but not via publicly accessible channels.",
+        "RED": "The BOM is subject to restricted distribution to individual recipients only and must not be shared.",
+        "CLEAR": "The BOM is not subject to any restrictions as regards the sharing of the information within the BOM."
       }
     },
     "tool": {

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -256,6 +256,12 @@ limitations under the License.
                         Formal registration is optional.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="distribution" type="bom:tlpType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The Traffic Light Protocol (TLP) classification that controls the sharing and distribution
+                        of the component that the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
@@ -389,6 +395,49 @@ limitations under the License.
             </xs:annotation>
         </xs:anyAttribute>
     </xs:complexType>
+
+    <xs:simpleType name="tlpType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CLEAR">
+                <xs:annotation>
+                    <xs:documentation>
+                        The BOM is not subject to any restrictions as regards the sharing of the information within the BOM.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GREEN">
+                <xs:annotation>
+                    <xs:documentation>
+                        The BOM is subject to limited disclosure, and recipients can share the BOM within their community
+                        but not via publicly accessible channels.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMBER">
+                <xs:annotation>
+                    <xs:documentation>
+                        The BOM is subject to limited disclosure, and recipients can only share the BOM on a need-to-know
+                        basis within their organization and with clients.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMBER+STRICT">
+                <xs:annotation>
+                    <xs:documentation>
+                        The BOM is subject to limited disclosure, and recipients can only share the BOM on a need-to-know
+                        basis within their organization.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RED">
+                <xs:annotation>
+                    <xs:documentation>
+                        The BOM is subject to restricted distribution to individual recipients only and must not be shared.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+         </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="toolType">
         <xs:annotation>


### PR DESCRIPTION
As discussed in ticket #595 this PR adds TLP marking to the metadata to indicate the sharing and distribution constraints for the BOM.


fixes https://github.com/CycloneDX/specification/issues/595

