### PR TITLE
Add `support-policy` external reference type

### DIFF
--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -320,6 +320,8 @@ enum ExternalReferenceType {
   EXTERNAL_REFERENCE_TYPE_RFC_9116 = 41;
   // Reference to release notes
   EXTERNAL_REFERENCE_TYPE_RELEASE_NOTES = 42;
+  // A document specifying the lifecycle phase of the component and its support status. The document might be machine-readable (Common Lifecycle Enumeration, OpenEOX) or human-readable.
+  EXTERNAL_REFERENCE_TYPE_SUPPORT_POLICY = 43;
 }
 
 enum HashAlg {

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -1805,6 +1805,7 @@
             "electronic-signature",
             "digital-signature",
             "rfc-9116",
+            "support-policy",
             "other"
           ],
           "meta:enum": {
@@ -1850,6 +1851,7 @@
             "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
             "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
             "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+            "support-policy": "A document specifying the lifecycle phase of the component and its support policy. The document might be machine-readable (Common Lifecycle Enumeration, OpenEOX) or human-readable.",
             "other": "Use this if no other types accurately describe the purpose of the external reference."
           }
         },

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -1578,6 +1578,11 @@ limitations under the License.
                     <xs:documentation>Document that complies with RFC-9116 (A File Format to Aid in Security Vulnerability Disclosure)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="support-policy">
+                <xs:annotation>
+                    <xs:documentation>A document specifying the lifecycle phase of the component and its support status. The document might be machine-readable (Common Lifecycle Enumeration, OpenEOX) or human-readable.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="other">
                 <xs:annotation>
                     <xs:documentation>Use this if no other types accurately describe the purpose of the external reference</xs:documentation>

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.json
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.json
@@ -209,6 +209,10 @@
           "url": "http://example.com/extref/rfc-9116"
         },
         {
+          "type": "support-policy",
+          "url": "https://example.com/extref/cle.json"
+        },
+        {
           "type": "other",
           "url": "http://example.com/extref/other"
         }

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.textproto
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.textproto
@@ -203,6 +203,10 @@ components {
     url: "http://example.com/extref/rfc-9116"
   }
   external_references {
+    type: EXTERNAL_REFERENCE_TYPE_SUPPORT_POLICY
+    url: "https://example.com/extref/cle.json"
+  }
+  external_references {
     type: EXTERNAL_REFERENCE_TYPE_OTHER
     url: "http://example.com/extref/other"
   }

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.xml
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.xml
@@ -70,6 +70,7 @@
                 <reference type="electronic-signature"><url>http://example.com/extref/electronic-signature</url></reference>
                 <reference type="digital-signature"><url>http://example.com/extref/digital-signature</url></reference>
                 <reference type="rfc-9116"><url>http://example.com/extref/rfc-9116</url></reference>
+                <reference type="support-policy"><url>https://example.com/extref/cle.json</url></reference>
                 <reference type="other"><url>http://example.com/extref/other</url></reference>
             </externalReferences>
         </component>


### PR DESCRIPTION
Adds a new external reference type to reference documents such as:

- a [Common Lifecycle Enumeration](https://github.com/Ecma-TC54/tg3) document.
- an [OpenEOX](https://openeox.org/) document.
- a human-readable document specifying end-of-life or end-of-support dates for the CycloneDX component.

Closes #591
