### PR TITLE
Add `tea-collection` external reference type

### DIFF
--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -320,6 +320,8 @@ enum ExternalReferenceType {
   EXTERNAL_REFERENCE_TYPE_RFC_9116 = 41;
   // Reference to release notes
   EXTERNAL_REFERENCE_TYPE_RELEASE_NOTES = 42;
+  // The URL to the latest TEA Collection on a Transparency Exchange API server.
+  EXTERNAL_REFERENCE_TYPE_TEA_COLLECTION = 43;
 }
 
 enum HashAlg {

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -1805,6 +1805,7 @@
             "electronic-signature",
             "digital-signature",
             "rfc-9116",
+            "tea-collection",
             "other"
           ],
           "meta:enum": {
@@ -1850,6 +1851,7 @@
             "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
             "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
             "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+            "tea-collection": "The URL to the latest TEA Collection on a Transparency Exchange API server.",
             "other": "Use this if no other types accurately describe the purpose of the external reference."
           }
         },

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -1578,6 +1578,11 @@ limitations under the License.
                     <xs:documentation>Document that complies with RFC-9116 (A File Format to Aid in Security Vulnerability Disclosure)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="tea-collection">
+                <xs:annotation>
+                    <xs:documentation>The URL to the latest TEA Collection on a Transparency Exchange API server.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="other">
                 <xs:annotation>
                     <xs:documentation>Use this if no other types accurately describe the purpose of the external reference</xs:documentation>

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.json
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.json
@@ -209,6 +209,10 @@
           "url": "http://example.com/extref/rfc-9116"
         },
         {
+          "type": "tea-collection",
+          "url": "https://example.com/tea/v1/release/3f92c28c-13c9-4e32-8d5b-5f8ae77ef265/collection"
+        },
+        {
           "type": "other",
           "url": "http://example.com/extref/other"
         }

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.textproto
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.textproto
@@ -203,6 +203,10 @@ components {
     url: "http://example.com/extref/rfc-9116"
   }
   external_references {
+    type: EXTERNAL_REFERENCE_TYPE_TEA_COLLECTION
+    url: "https://example.com/tea/v1/release/3f92c28c-13c9-4e32-8d5b-5f8ae77ef265/collection"
+  }
+  external_references {
     type: EXTERNAL_REFERENCE_TYPE_OTHER
     url: "http://example.com/extref/other"
   }

--- a/tools/src/test/resources/1.7/valid-external-reference-1.7.xml
+++ b/tools/src/test/resources/1.7/valid-external-reference-1.7.xml
@@ -70,6 +70,7 @@
                 <reference type="electronic-signature"><url>http://example.com/extref/electronic-signature</url></reference>
                 <reference type="digital-signature"><url>http://example.com/extref/digital-signature</url></reference>
                 <reference type="rfc-9116"><url>http://example.com/extref/rfc-9116</url></reference>
+                <reference type="tea-collection"><url>https://example.com/tea/v1/release/3f92c28c-13c9-4e32-8d5b-5f8ae77ef265/collection</url></reference>
                 <reference type="other"><url>http://example.com/extref/other</url></reference>
             </externalReferences>
         </component>


### PR DESCRIPTION
Adds a new type to reference a [TEA Collection object](https://github.com/CycloneDX/transparency-exchange-api/blob/main/tea-collection/tea-collection.md). A Transparency Exchange API Collection for the most part is a replacement of the `externalReferences` object, but provides a **versioned** and modifiable view of all security-related documents for a given CycloneDX Component.

The easiest way to integrate a TEA Collection into CycloneDX is to introduce a new type of `externalReference` that points:

- either to the TEA Collection object itself (this is what this PR proposes)
- or to the TEA Component Release object (currently undocumented)

Closes #633
