### PR TITLE
refactor: metadata distribution to be an object

### DIFF
--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -559,6 +559,11 @@ enum LicensingTypeEnum {
 }
 
 message Metadata {
+  message DistributionConstraints {
+    // The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes.
+    optional TlpClassification tlp = 1;
+  }
+
   // The date and time (timestamp) when the document was created.
   optional google.protobuf.Timestamp timestamp = 1;
   // The tool(s) used in the creation of the BOM.
@@ -580,8 +585,8 @@ message Metadata {
   repeated Lifecycles lifecycles = 9;
   // The organization that created the BOM. Manufacturer is common in BOMs created through automated processes. BOMs created through manual means may have '.authors' instead.
   optional OrganizationalEntity manufacturer = 10;
-  // The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes.
-  optional TlpClassification distribution = 11;
+  // Constraints of sharing and distribution of the data that the BOM describes.
+  optional DistributionConstraints distributionConstraints = 11;
 }
 
 message Lifecycles {

--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -585,7 +585,7 @@ message Metadata {
   repeated Lifecycles lifecycles = 9;
   // The organization that created the BOM. Manufacturer is common in BOMs created through automated processes. BOMs created through manual means may have '.authors' instead.
   optional OrganizationalEntity manufacturer = 10;
-  // Constraints of sharing and distribution of the data that the BOM describes.
+  // Conditions and constraints governing the sharing and distribution of the data or components described by this BOM.
   optional DistributionConstraints distributionConstraints = 11;
 }
 

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -723,10 +723,17 @@
           "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {"$ref": "#/definitions/property"}
         },
-        "distribution": {
-          "title": "Distribution",
+        "distributionConstraints": {
+          "title": "Distribution Constraints",
           "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes.",
-          "$ref": "#/definitions/tlpClassification"
+          "type": "object",
+          "properties": {
+            "tlp": {
+              "$ref": "#/definitions/tlpClassification",
+              "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes."
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -725,7 +725,7 @@
         },
         "distributionConstraints": {
           "title": "Distribution Constraints",
-          "description": "Constraints of sharing and distribution of the data that the BOM describes.",
+          "description": "Conditions and constraints governing the sharing and distribution of the data or components described by this BOM.",
           "type": "object",
           "properties": {
             "tlp": {

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -725,7 +725,7 @@
         },
         "distributionConstraints": {
           "title": "Distribution Constraints",
-          "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes.",
+          "description": "Constraints of sharing and distribution of the data that the BOM describes.",
           "type": "object",
           "properties": {
             "tlp": {

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -259,7 +259,8 @@ limitations under the License.
             <xs:element name="distributionConstraints" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Constraints of sharing and distribution of the data that the BOM describes.
+                        Conditions and constraints governing the sharing and distribution of the data or components
+                        described by this BOM.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -256,21 +256,23 @@ limitations under the License.
                         Formal registration is optional.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:complexType name="distributionConstraints" minOccurs="0" maxOccurs="1">
+            <xs:element name="distributionConstraints" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Constraints of sharing and distribution of the data that the BOM describes.</xs:documentation>
                 </xs:annotation>
-                <xs:sequence>
-                    <xs:element name="tlp" type="bom:tlpClassificationType" default="CLEAR" minOccurs="0" maxOccurs="1">
-                        <xs:annotation>
-                            <xs:documentation>
-                                The Traffic Light Protocol (TLP) classification that controls the sharing and
-                                distribution of the data that the BOM describes.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
-                </xs:sequence>
-            </xs:complexType>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="tlp" type="bom:tlpClassificationType" default="CLEAR" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The Traffic Light Protocol (TLP) classification that controls the sharing and
+                                    distribution of the data that the BOM describes.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -256,12 +256,21 @@ limitations under the License.
                         Formal registration is optional.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="distribution" type="bom:tlpClassificationType" default="CLEAR" minOccurs="0" maxOccurs="1">
+            <xs:complexType name="distributionConstraints" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>The Traffic Light Protocol (TLP) classification that controls the sharing and distribution
-                        of the data that the BOM describes.</xs:documentation>
+                    <xs:documentation>Constraints of sharing and distribution of the data that the BOM describes.</xs:documentation>
                 </xs:annotation>
-            </xs:element>
+                <xs:sequence>
+                    <xs:element name="tlp" type="bom:tlpClassificationType" default="CLEAR" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The Traffic Light Protocol (TLP) classification that controls the sharing and
+                                distribution of the data that the BOM describes.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:complexType>
             <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -258,7 +258,9 @@ limitations under the License.
             </xs:element>
             <xs:element name="distributionConstraints" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Constraints of sharing and distribution of the data that the BOM describes.</xs:documentation>
+                    <xs:documentation>
+                        Constraints of sharing and distribution of the data that the BOM describes.
+                    </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>

--- a/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.json
+++ b/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.json
@@ -5,7 +5,9 @@
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "version": 1,
   "metadata": {
-    "distribution": "RED"
+    "distributionConstraints": {
+      "tlp": "RED"
+    }
   },
   "components": []
 }

--- a/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.textproto
+++ b/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.textproto
@@ -5,5 +5,7 @@ spec_version: "1.7"
 version: 1
 serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
 metadata {
-  distribution: TLP_CLASSIFICATION_RED
+  distributionConstraints {
+    tlp: TLP_CLASSIFICATION_RED
+  }
 }

--- a/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.xml
+++ b/tools/src/test/resources/1.7/valid-metadata-distribution-1.7.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.7">
     <metadata>
-        <distribution>RED</distribution>
+        <distributionConstraints>
+            <tlp>RED</tlp>
+        </distributionConstraints>
     </metadata>
     <components />
 </bom>


### PR DESCRIPTION
Refactored `metadata.distribution` to be more verbose in its name, and made it more versatile by converting it to an "object" with "TLP" as a property.

caused by https://github.com/CycloneDX/specification/pull/603#issuecomment-2972771553