### PR TITLE
Fix `oneOf` error for certificate

### DIFF
--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -5474,9 +5474,9 @@
                     ],
                     "additionalProperties": false,
                     "properties": {
-                      "state": {
+                      "name": {
                         "type": "string",
-                        "title": "State",
+                        "title": "Custom State Name",
                         "description": "The name of the certificate lifecycle state."
                       },
                       "description": {
@@ -5536,14 +5536,14 @@
                   {
                     "title": "Common Extensions",
                     "required": [
-                      "name",
+                      "extension",
                       "value"
                     ],
                     "additionalProperties": false,
                     "properties": {
-                      "name": {
+                      "extension": {
                         "type": "string",
-                        "title": "name",
+                        "title": "extension",
                         "description": "The name of the extension.",
                         "enum": [
                           "basicConstraints",


### PR DESCRIPTION
This PR fixes the `oneOf` issue for `certificateExtensions` and `certificateState`
