### PR TITLE
Extend crypto definitions

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -426,15 +426,7 @@
         {
           "pattern": "ML-DSA-(44|65|87)",
           "primitive": "signature"
-        }
-      ]
-    },
-    {
-      "family": "HashML-DSA",
-      "standard": [
-        {"name": "FIPS 204", "url": "https://doi.org/10.6028/NIST.FIPS.204"}
-      ],
-      "variant": [
+        },
         {
           "pattern": "HashML-DSA-(44|65|87)[-{hashFunction}]",
           "primitive": "signature"
@@ -442,13 +434,17 @@
       ]
     },
     {
-      "family": "HashSLH-DSA",
+      "family": "SLH-DSA",
       "standard": [
         {"name": "FIPS 205", "url": "https://doi.org/10.6028/NIST.FIPS.205"}
       ],
       "variant": [
         {
-          "pattern": "HashSLH-DSA-(SHA2|SHAKE)-(128s|128f|192s|192f|256s|256f)",
+          "pattern": "SLH-DSA-(SHA2|SHAKE)-(128s|128f|192s|192f|256s|256f)",
+          "primitive": "signature"
+        },
+        {
+          "pattern": "HashSLH-DSA-(SHA2|SHAKE)-(128s|128f|192s|192f|256s|256f)[-{hashFunction}]",
           "primitive": "signature"
         }
       ]
@@ -688,7 +684,7 @@
       ]
     },
     {
-      "family": "BLAKE2b",
+      "family": "BLAKE2",
       "standard": [
         {"name": "RFC7693", "url": "https://doi.org/10.17487/RFC7693"}
       ],
@@ -700,6 +696,26 @@
         {
           "pattern": "BLAKE2b-(160|256|384|512)-HMAC",
           "primitive": "mac"
+        },
+        {
+          "pattern": "BLAKE2s-(160|256)",
+          "primitive": "hash"
+        },
+        {
+          "pattern": "BLAKE2b-(160|256|384|512)-HMAC",
+          "primitive": "mac"
+        }
+      ]
+    },
+    {
+      "family": "BLAKE3",
+      "standard": [
+        {"name": "BLAKE3 Spec", "url": "https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf"}
+      ],
+      "variant": [
+        {
+          "pattern": "BLAKE3[-{outputLength}]",
+          "primitive": "hash"
         }
       ]
     },
@@ -808,6 +824,180 @@
         {
           "pattern": "3GPP-XOR[-KDF]",
           "primitive": "kdf"
+        }
+      ]
+    },
+        {
+      "family": "MD2",
+      "standard": [
+        {"name": "RFC1319", "url": "https://doi.org/10.17487/RFC1319"}
+      ],
+      "variant": [
+        {
+          "pattern": "MD2",
+          "primitive": "hash"
+        }
+      ]
+    },
+    {
+      "family": "MD4",
+      "standard": [
+        {"name": "RFC1320", "url": "https://doi.org/10.17487/RFC1320"}
+      ],
+      "variant": [
+        {
+          "pattern": "MD4",
+          "primitive": "hash"
+        }
+      ]
+    },
+    {
+      "family": "MD5",
+      "standard": [
+        {"name": "RFC1321", "url": "https://doi.org/10.17487/RFC1321"}
+      ],
+      "variant": [
+        {
+          "pattern": "MD5",
+          "primitive": "hash"
+        }
+      ]
+    },
+    {
+      "family": "RIPEMD",
+      "standard": [
+        {"name": "ISO10118-3", "url": "https://www.iso.org/standard/67116.html"}
+      ],
+      "variant": [
+        {
+          "pattern": "RIPEMD-(128|160|256|320)",
+          "primitive": "hash"
+        }
+      ]
+    },
+    {
+      "family": "Whirlpool",
+      "standard": [
+        {"name": "ISO10118-3", "url": "https://www.iso.org/standard/67116.html"},
+        {"name": "NESSIE", "url": "https://www.cosic.esat.kuleuven.be/nessie/"}
+      ],
+      "variant": [
+        {
+          "pattern": "Whirlpool",
+          "primitive": "hash"
+        }
+      ]
+    },
+    {
+      "family": "Serpent",
+      "standard": [
+        {"name": "AES Finalist", "url": "https://www.cl.cam.ac.uk/~rja14/serpent.html"}
+      ],
+      "variant": [
+        {
+          "pattern": "Serpent-(128|192|256)[-{mode}][-{padding}]",
+          "primitive": "block-cipher"
+        }
+      ]
+    },
+    {
+      "family": "CAST5",
+      "standard": [
+        {"name": "RFC2144", "url": "https://doi.org/10.17487/RFC2144"}
+      ],
+      "variant": [
+        {
+          "pattern": "CAST5[-{keyLength}][-{mode}]",
+          "primitive": "block-cipher"
+        }
+      ]
+    },
+    {
+      "family": "CAST6",
+      "standard": [
+        {"name": "RFC2612", "url": "https://doi.org/10.17487/RFC2612"}
+      ],
+      "variant": [
+        {
+          "pattern": "CAST6[-{keyLength}][-{mode}]",
+          "primitive": "block-cipher"
+        }
+      ]
+    },
+    {
+      "family": "RC5",
+      "standard": [
+        {"name": "RFC2040", "url": "https://doi.org/10.17487/RFC2040"}
+      ],
+      "variant": [
+        {
+          "pattern": "RC5[-{keyLength}][-{mode}]",
+          "primitive": "block-cipher"
+        }
+      ]
+    },
+    {
+      "family": "HC",
+      "standard": [
+        {"name": "eSTREAM", "url": "https://www.ecrypt.eu.org/stream/"}
+      ],
+      "variant": [
+        {
+          "pattern": "HC-128",
+          "primitive": "stream-cipher"
+        },
+        {
+          "pattern": "HC-256",
+          "primitive": "stream-cipher"
+        }
+      ]
+    },
+    {
+      "family": "RABBIT",
+      "standard": [
+        {"name": "RFC4503", "url": "https://doi.org/10.17487/RFC4503"},
+        {"name": "eSTREAM", "url": "https://www.ecrypt.eu.org/stream/"}
+      ],
+      "variant": [
+        {
+          "pattern": "RABBIT",
+          "primitive": "stream-cipher"
+        }
+      ]
+    },
+    {
+      "family": "Ascon",
+      "standard": [
+        {"name": "NIST SP 800-232", "url": "https://doi.org/10.6028/NIST.SP.800-232"}
+      ],
+      "variant": [
+        {
+          "pattern": "Ascon-AEAD128",
+          "primitive": "ae"
+        },
+        {
+          "pattern": "Ascon-Hash256",
+          "primitive": "hash"
+        },
+        {
+          "pattern": "Ascon-XOF128",
+          "primitive": "xof"
+        },
+        {
+          "pattern": "Ascon-CXOF128",
+          "primitive": "xof"
+        }
+      ]
+    },
+    {
+      "family": "SipHash",
+      "standard": [
+        {"name": "SipHash Spec", "url": "https://131002.net/siphash/"}
+      ],
+      "variant": [
+        {
+          "pattern": "SipHash[-{compressionRounds}-{finalizationRounds}]",
+          "primitive": "hash"
         }
       ]
     }


### PR DESCRIPTION
This PR further extends the list of algorithms in cryptography-defs.json.

<!-- 
Thank you for taking the time to develop and contribute a core enhancement or fix for a defect!

We kindly request that you create pull requests only for things that have been discussed in a ticket first; exceptions may be made for spelling or grammar fixes.
Read more about the process here: https://cyclonedx.org/participate/standardization-process/#working-model

Please have the related ticket/issue ID ready. 
If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose

-->

<!-- 

Please provide a brief description of what this pull request intends to do and which ticket it fixes/closes.  
Example: 
> As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum.
>
> fixes #485 

In case this is for a spelling or grammar improvement, please provide a brief description.
Example:
> Fixe typo: color(AE) -> colour(BE)

-->
