### PR TITLE
fix: remove the word "optional", align some docs

### DIFF
--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 message AttachedText {
   // Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents. [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
   optional string content_type = 1;
-  // Specifies the optional encoding the text is represented in
+  // Specifies the encoding the text is represented in
   optional string encoding = 2;
   // SimpleContent value of element. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.
   string value = 3;
@@ -33,9 +33,9 @@ message Bom {
   repeated Composition compositions = 9;
   // Vulnerabilities identified in components or services.
   repeated Vulnerability vulnerabilities = 10;
-  // Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinion or commentary from various stakeholders.
+  // Comments made by people, organizations, or tools about any object with a bom_ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinion or commentary from various stakeholders.
   repeated Annotation annotations = 11;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 12;
   // Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself. This may encompass how the object was created, assembled, deployed, tested, certified, or otherwise brought into its present form. Common examples include software build pipelines, deployment processes, AI/ML model training, cryptographic key generation or certification, and third-party audits. Processes are modeled using declared and observed formulas, composed of workflows, tasks, and individual steps.
   repeated Formula formulation = 13;
@@ -95,9 +95,9 @@ message Commit {
 message Component {
   // Specifies the type of component. For software components, classify as an application if no more specific appropriate classification is available or cannot be determined for the component.
   Classification type = 1;
-  // The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.
+  // The mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.
   optional string mime_type = 2;
-  // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 3;
   // The organization that supplied the component. The supplier may often be the manufacturer but may also be a distributor or repackager.
   optional OrganizationalEntity supplier = 4;
@@ -127,7 +127,7 @@ message Component {
   repeated Hash hashes = 12;
   // A list of SPDX licenses and/or named licenses and/or SPDX License Expression.
   repeated LicenseChoice licenses = 13;
-  // An optional copyright notice informing users of the underlying claims to copyright ownership in a published work.
+  // An copyright notice informing users of the underlying claims to copyright ownership in a published work.
   optional string copyright = 14;
   // DEPRECATED - DO NOT USE. This will be removed in a future version. Specifies a well-formed CPE name. See https://nvd.nist.gov/products/cpe
   optional string cpe = 15;
@@ -141,13 +141,13 @@ message Component {
   optional Pedigree pedigree = 19;
   // Provides the ability to document external references related to the component or to the project the component describes.
   repeated ExternalReference external_references = 20;
-  // Specifies optional sub-components. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
+  // Specifies sub-components. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
   repeated Component components = 21;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 22;
-  // Specifies optional license and copyright evidence.
+  // Specifies license and copyright evidence.
   optional Evidence evidence = 23;
-  // Specifies optional release notes.
+  // Specifies release notes.
   optional ReleaseNotes releaseNotes = 24;
   // A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.
   optional ModelCard modelCard = 25;
@@ -194,7 +194,7 @@ message DataFlow {
 // Specifies the flow direction of the data. Valid values are: inbound, outbound, bi-directional, and unknown. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known.
 // buf:lint:ignore ENUM_VALUE_PREFIX -- Enum value names should be prefixed with "DATA_FLOW_DIRECTION_"
 enum DataFlowDirection {
-  // Default
+  // Default.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   DATA_FLOW_NULL = 0;
   // Data that enters a service.
@@ -209,17 +209,17 @@ enum DataFlowDirection {
 
 // Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.
 message Dependency {
-  // References a component or service by its bom-ref attribute
+  // References a component or service by its bom_ref attribute
   string ref = 1;
-  // The bom-ref identifiers of the components or services that are dependencies of this dependency object.
+  // The bom_ref identifiers of the components or services that are dependencies of this dependency object.
   repeated Dependency dependencies = 2;
-  // The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.
+  // The bom_ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.
   repeated string provides = 3;
 }
 
 // The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff
 message Diff {
-  // Specifies the optional text of the diff
+  // Specifies the text of the diff
   optional AttachedText text = 1;
   // Specifies the URL to the diff
   optional string url = 2;
@@ -231,16 +231,16 @@ message ExternalReference {
   ExternalReferenceType type = 1;
   // The URL to the external reference
   string url = 2;
-  // An optional comment describing the external reference
+  // A comment describing the external reference
   optional string comment = 3;
-  // Optional integrity hashes for the external resource content
+  // Integrity hashes for the external resource content
   repeated Hash hashes = 4;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 5;
 }
 
 enum ExternalReferenceType {
-  // Use this if no other types accurately describe the purpose of the external reference
+  // Use this if no other types accurately describe the purpose of the external reference.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `other` is our fallback, doubling `unspecified`
   EXTERNAL_REFERENCE_TYPE_OTHER = 0;
   // Version Control System
@@ -374,7 +374,7 @@ message IdentifiableAction {
 }
 
 enum IssueClassification {
-  // Default
+  // Default.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   ISSUE_CLASSIFICATION_NULL = 0;
   // A fault, flaw, or bug in software
@@ -432,15 +432,15 @@ message License {
     // The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.
     string name = 2;
   }
-  // Specifies the optional full text of the attachment
+  // Specifies the full text of the attachment
   optional AttachedText text = 3;
   // The URL to the attachment file. If the attachment is a license or BOM, an externalReference should also be specified for completeness.
   optional string url = 4;
-  // An optional identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 5;
   // Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata
   optional Licensing licensing = 6;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 7;
   // Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.
   optional LicenseAcknowledgementEnumeration acknowledgement = 8;
@@ -460,9 +460,9 @@ message LicenseExpressionDetailed {
     // - "GPL-3.0-only WITH Classpath-exception-2.0"
     // - "LicenseRef-my-custom-license"
     string license_identifier = 1;
-    // An optional identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+    // A identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
     optional string bom_ref = 2;
-    // An optional way to include the textual content of the license.
+    // A way to include the textual content of the license.
     optional AttachedText text = 3;
     // The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness
     optional string url = 4;
@@ -476,13 +476,13 @@ message LicenseExpressionDetailed {
   // Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata
   // Details for parts of the `expression`.
   repeated ExpressionDetails details = 2;
-  // An optional identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the license elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 3;
   // Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.
   optional LicenseAcknowledgementEnumeration acknowledgement = 4;
   // Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata
   optional Licensing licensing = 5;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 6;
 }
 
@@ -579,7 +579,7 @@ message Metadata {
   // The license information for the BOM document. This may be different from the license(s) of the component(s) that the BOM describes.
   // A list of SPDX licenses and/or named licenses and/or SPDX License Expression.
   repeated LicenseChoice licenses = 7;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 8;
   // Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.
   repeated Lifecycles lifecycles = 9;
@@ -625,7 +625,7 @@ message OrganizationalContact {
   optional string email = 2;
   // The phone number of the contact.
   optional string phone = 3;
-  // An optional identifier which can be used to reference the object elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the object elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 4;
 }
 
@@ -636,14 +636,14 @@ message OrganizationalEntity {
   repeated string url = 2;
   // A contact person at the organization. Multiple contacts are allowed.
   repeated OrganizationalContact contact = 3;
-  // An optional identifier which can be used to reference the object elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the object elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 4;
   // The physical address (location) of the organization
   optional PostalAddressType address = 5;
 }
 
 enum PatchClassification {
-  // Default
+  // Default.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   PATCH_CLASSIFICATION_NULL = 0;
   // A patch which is not developed by the creators or maintainers of the software being patched. Refer to https://en.wikipedia.org/wiki/Unofficial_patch
@@ -694,7 +694,7 @@ enum Scope {
 }
 
 message Service {
-  // An optional identifier which can be used to reference the service elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the service elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 1;
   // The organization that provides the service.
   optional OrganizationalEntity provider = 2;
@@ -718,11 +718,11 @@ message Service {
   repeated LicenseChoice licenses = 11;
   // Provides the ability to document external references related to the service.
   repeated ExternalReference external_references = 12;
-  // Specifies optional sub-service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
+  // Specifies sub-service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
   repeated Service services = 13;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 14;
-  // Specifies optional release notes.
+  // Specifies release notes.
   optional ReleaseNotes releaseNotes = 15;
   // The name of the trust zone the service resides in.
   optional string trustZone = 16;
@@ -823,9 +823,9 @@ message Composition {
   repeated string assemblies = 2;
   // The dependencies the aggregate completeness applies to
   repeated string dependencies = 3;
-  // The bom-ref identifiers of the vulnerabilities being described.
+  // The bom_ref identifiers of the vulnerabilities being described.
   repeated string vulnerabilities = 4;
-  // An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the composition elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 5;
 }
 
@@ -859,7 +859,7 @@ message Callstack {
     string module = 2;
     // A block of code designed to perform a particular task.
     optional string function = 3;
-    // Optional arguments that are passed to the module or function.
+    // Arguments that are passed to the module or function.
     repeated string parameters = 4;
     // The line number the code that is called resides on.
     optional int32 line = 5;
@@ -877,7 +877,7 @@ message EvidenceIdentity {
   optional float confidence = 2;
   // The methods used to extract and/or analyze the evidence.
   repeated EvidenceMethods methods = 3;
-  // The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation.
+  // The object in the BOM identified by its bom_ref. This is often a component or service, but may be any object type supporting bom_refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation.
   repeated string tools = 4;
   // The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available).
   optional string concludedValue = 5;
@@ -893,7 +893,7 @@ message EvidenceMethods {
 }
 
 message EvidenceOccurrences {
-  // An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the occurrence elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 1;
   // The location or path to where the component was found.
   string location = 2;
@@ -957,7 +957,7 @@ message ReleaseNotes {
   optional string description = 5;
   // The date and time (timestamp) when the release note was created.
   optional google.protobuf.Timestamp timestamp = 6;
-  // Optional alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names).
+  // Alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names).
   repeated string aliases = 7;
   // Textual strings that aid in the discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes. Examples include "json-parser", "object-persistence", "text-to-image", "translation", and "object-detection".
   repeated string tags = 8;
@@ -965,13 +965,13 @@ message ReleaseNotes {
   repeated Issue resolves = 9;
   // Zero or more release notes containing the locale and content. Multiple note messages may be specified to support release notes in a wide variety of languages.
   repeated Note notes = 10;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 11;
 }
 
 // Defines a weakness in a component or service that could be exploited or triggered by a threat source.
 message Vulnerability {
-  // An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the vulnerability elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 1;
   // The identifier that uniquely identifies the vulnerability.
   optional string id = 2;
@@ -1005,7 +1005,7 @@ message Vulnerability {
   optional VulnerabilityAnalysis analysis = 16;
   // affects
   repeated VulnerabilityAffects affects = 17;
-  // Specifies optional, custom, properties
+  // Specifies custom properties.
   repeated Property properties = 18;
   // The date and time (timestamp) when the vulnerability record was rejected (if applicable).
   optional google.protobuf.Timestamp rejected = 19;
@@ -1042,13 +1042,13 @@ message VulnerabilityRating {
   optional ScoreMethod method = 4;
   // Textual representation of the metric values used to score the vulnerability.
   optional string vector = 5;
-  // An optional reason for rating the vulnerability as it was.
+  // A reason for rating the vulnerability as it was.
   optional string justification = 6;
 }
 
 // Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.
 enum Severity {
-  // The severity is not known
+  // The severity is not known.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `unknown` is our fallback, doubling `unspecified`
   SEVERITY_UNKNOWN = 0;
   // Critical severity
@@ -1066,7 +1066,7 @@ enum Severity {
 }
 
 enum ScoreMethod {
-  // An undefined score method
+  // An undefined score method.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   SCORE_METHOD_NULL = 0;
   // Common Vulnerability Scoring System v2 - https://www.first.org/cvss/v2/
@@ -1087,7 +1087,7 @@ enum ScoreMethod {
 
 // Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.
 message Advisory {
-  // An optional name of the advisory.
+  // A name of the advisory.
   optional string title = 1;
   // Location where the advisory can be obtained.
   string url = 2;
@@ -1116,7 +1116,7 @@ message VulnerabilityAnalysis {
 }
 
 enum ImpactAnalysisState {
-  // An undefined impact analysis state
+  // An undefined impact analysis state.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   IMPACT_ANALYSIS_STATE_NULL = 0;
   // The vulnerability has been remediated.
@@ -1134,7 +1134,7 @@ enum ImpactAnalysisState {
 }
 
 enum ImpactAnalysisJustification {
-  // An undefined impact analysis justification
+  // An undefined impact analysis justification.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   IMPACT_ANALYSIS_JUSTIFICATION_NULL = 0;
   // The code has been removed or tree-shaked.
@@ -1158,7 +1158,7 @@ enum ImpactAnalysisJustification {
 }
 
 enum VulnerabilityResponse {
-  // unspecified value
+  // unspecified value.
   // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- `null` is our fallback, doubling `unspecified`
   VULNERABILITY_RESPONSE_NULL = 0;
   // Can not fix
@@ -1174,7 +1174,7 @@ enum VulnerabilityResponse {
 }
 
 message VulnerabilityAffects {
-  // References a component or service by the objects bom-ref
+  // References a component or service by the objects bom_ref
   string ref = 1;
   // Zero or more individual versions or range of versions.
   repeated VulnerabilityAffectedVersions versions = 2;
@@ -1216,9 +1216,9 @@ message AnnotatorChoice {
 }
 
 message Annotation {
-  // An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the annotation elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 1;
-  // The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs.
+  // The object in the BOM identified by its bom_ref. This is often a component or service but may be any object type supporting bom_refs.
   repeated string subjects = 2;
   // The organization, person, component, or service which created the textual content of the annotation.
   AnnotatorChoice annotator = 3;
@@ -1235,7 +1235,7 @@ message Annotation {
  * Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.
  */
 message ModelCard {
-  // An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the model card elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 1;
   // Hyper-parameters for construction of the model.
   optional ModelParameters modelParameters = 2;
@@ -1269,7 +1269,7 @@ message ModelCard {
       oneof choice {
         // Inline Data Information
         ComponentData dataset = 1;
-        // References a data component by the components bom-ref attribute
+        // References a data component by the components bom_ref attribute
         string ref = 2;
       }
     }
@@ -1338,7 +1338,7 @@ message ModelCard {
     message EnvironmentalConsiderations {
       // Describes energy consumption information incurred for one or more component lifecycle activities.
       repeated EnergyConsumption energyConsumptions = 1;
-      // Specifies optional, custom properties for environment considerations
+      // Specifies custom properties for environment considerations.
       repeated Property properties = 2;
     }
     // Describes energy consumption information incurred for the specified lifecycle activity.
@@ -1377,7 +1377,7 @@ message ModelCard {
       optional CO2MeasureType co2CostEquivalent = 4;
       // The CO2 offset or credit for the CO2 equivalent cost.
       optional CO2MeasureType co2CostOffset = 5;
-      // Specifies optional, custom properties for environment considerations
+      // Specifies custom properties for environment considerations.
       repeated Property properties = 6;
     }
   }
@@ -1461,7 +1461,7 @@ message CO2MeasureType {
 
 // An address used to identify a contactable location.
 message PostalAddressType {
-  // An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the address elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 1;
   // The country name or the two-letter ISO 3166-1 country code.
   optional string country = 2;
@@ -1478,8 +1478,8 @@ message PostalAddressType {
 }
 
 enum ModelParameterApproachType {
-  // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- value `0` is a fallback(meaning "unspecified") in protobuf3. this usage here is an error, it shall be fixed with v2.0 of this very schema
   // Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.
+  // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX -- value `0` is a fallback(meaning "unspecified") in protobuf3. this usage here is an error, it shall be fixed with v2.0 of this very schema
   MODEL_PARAMETER_APPROACH_TYPE_SUPERVISED = 0;
   // Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.
   MODEL_PARAMETER_APPROACH_TYPE_UNSUPERVISED = 1;
@@ -1492,7 +1492,7 @@ enum ModelParameterApproachType {
 }
 
 message ComponentData {
-  // An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref must be unique within the BOM.
+  // A identifier which can be used to reference the dataset elsewhere in the BOM. Every `bom_ref` must be unique within the BOM.
   optional string bom_ref = 1;
   // The general theme or subject matter of the data being specified.
   ComponentDataType type = 2;
@@ -1512,7 +1512,7 @@ message ComponentData {
   optional DataGovernance governance = 9;
 
   message ComponentDataContents {
-    // An optional way to include textual or encoded data.
+    // A way to include textual or encoded data.
     optional AttachedText attachment = 1;
     // The URL to where the data can be retrieved.
     optional string url = 2;
@@ -1838,10 +1838,10 @@ message OutputType {
   }
 }
 
-// Type that permits a choice to reference a resource using an iternal bom-ref identifier or an external reference.
+// Type that permits a choice to reference a resource using an iternal bom_ref identifier or an external reference.
 message ResourceReferenceChoice {
   oneof choice {
-    // References an object by its bom-ref attribute
+    // References an object by its bom_ref attribute
     string ref = 1;
     // Reference to an externally accessible resource
     ExternalReference externalReference = 2;
@@ -1908,7 +1908,7 @@ message EnvironmentVars {
 // The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.
 message Declarations {
   message Assessor {
-    // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+    // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
     optional string bom_ref = 1;
     // The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor.
     optional bool thirdParty = 2;
@@ -1927,7 +1927,7 @@ message Declarations {
         optional double score = 1;
         // The rationale for the conformance score.
         optional string rationale = 2;
-        // The list of  `bom-ref` to the evidence provided describing the mitigation strategies.
+        // The list of  `bom_ref` to the evidence provided describing the mitigation strategies.
         repeated string mitigationStrategies = 3;
       }
 
@@ -1939,11 +1939,11 @@ message Declarations {
         optional string rationale = 2;
       }
 
-      // The `bom-ref` to the requirement being attested to.
+      // The `bom_ref` to the requirement being attested to.
       optional string requirement = 1;
-      // The list of `bom-ref` to the claims being attested to.
+      // The list of `bom_ref` to the claims being attested to.
       repeated string claims = 2;
-      // The list of  `bom-ref` to the counter claims being attested to.
+      // The list of  `bom_ref` to the counter claims being attested to.
       repeated string counterClaims = 3;
       // The conformance of the claim meeting a requirement.
       optional AttestationConformance conformance = 4;
@@ -1953,26 +1953,26 @@ message Declarations {
 
     // The short description explaining the main points of the attestation.
     optional string summary = 1;
-    // The `bom-ref` to the assessor asserting the attestation.
+    // The `bom_ref` to the assessor asserting the attestation.
     optional string assessor = 2;
     // The grouping of requirements to claims and the attestors' declared conformance and confidence thereof.
     repeated AttestationMap map = 3;
   }
 
   message Claim {
-    // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+    // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
     optional string bom_ref = 1;
-    // The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to.
+    // The `bom_ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to.
     optional string target = 2;
     // The specific statement or assertion about the target.
     optional string predicate = 3;
-    // The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.
+    // The list of  `bom_ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.
     repeated string mitigationStrategies = 4;
     // The written explanation of why the evidence provided substantiates the claim.
     optional string reasoning = 5;
-    // The list of `bom-ref` to evidence that supports this claim.
+    // The list of `bom_ref` to evidence that supports this claim.
     repeated string evidence = 6;
-    // The list of `bom-ref` to counterEvidence that supports this claim.
+    // The list of `bom_ref` to counterEvidence that supports this claim.
     repeated string counterEvidence = 7;
     // External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.
     repeated ExternalReference externalReferences = 8;
@@ -1981,7 +1981,7 @@ message Declarations {
   message Evidence {
     message Data {
       message Contents {
-        // An optional way to include textual or encoded data.
+        // A way to include textual or encoded data.
         optional AttachedText attachment = 1;
         // The URL to where the data can be retrieved.
         optional string url = 2;
@@ -1999,7 +1999,7 @@ message Declarations {
       optional DataGovernance governance = 5;
     }
 
-    // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+    // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
     optional string bom_ref = 1;
     // The reference to the property name as defined in the CycloneDX Property Taxonomy: https://github.com/CycloneDX/cyclonedx-property-taxonomy/.
     optional string propertyName = 2;
@@ -2009,7 +2009,7 @@ message Declarations {
     repeated Data data = 4;
     // The date and time (timestamp) when the evidence was created.
     optional google.protobuf.Timestamp created = 5;
-    // The optional date and time (timestamp) when the evidence is no longer valid.
+    // The date and time (timestamp) when the evidence is no longer valid.
     optional google.protobuf.Timestamp expires = 6;
     // The author of the evidence.
     optional OrganizationalContact author = 7;
@@ -2062,9 +2062,9 @@ message Definition {
   // A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.
   message Standard {
     message Requirement {
-      // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+      // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
       optional string bom_ref = 1;
-      // The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref.
+      // The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom_ref.
       optional string identifier = 2;
       // The title of the requirement.
       optional string title = 3;
@@ -2074,16 +2074,16 @@ message Definition {
       repeated string descriptions = 5;
       // The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. The use of CRE promotes clear and unambiguous communication among stakeholders.
       repeated string openCre = 6;
-      // The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
+      // The `bom_ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
       optional string parent = 7;
-      // Specifies optional, custom, properties
+      // Specifies custom properties.
       repeated Property properties = 8;
       // External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.
       repeated ExternalReference externalReferences = 9;
     }
 
     message Level {
-      // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+      // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
       optional string bom_ref = 1;
       // The identifier used in the standard to identify a specific level.
       optional string identifier = 2;
@@ -2091,11 +2091,11 @@ message Definition {
       optional string title = 3;
       // The description of the level.
       optional string description = 4;
-      // The list of requirement `bom-ref`s that comprise the level.
+      // The list of requirement `bom_ref`s that comprise the level.
       repeated string requirements = 5;
     }
 
-    // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+    // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
     optional string bom_ref = 1;
     // The name of the standard. This will often be a shortened, single name of the standard.
     optional string name = 2;
@@ -2312,9 +2312,9 @@ message CryptoProperties {
     optional google.protobuf.Timestamp notValidBefore = 3;
     // The date and time according to ISO-8601 standard from which the certificate is not valid anymore
     optional google.protobuf.Timestamp notValidAfter = 4;
-    // The bom-ref to signature algorithm used by the certificate
+    // The bom_ref to signature algorithm used by the certificate
     optional string signatureAlgorithmRef = 5;
-    // The bom-ref to the public key of the subject
+    // The bom_ref to the public key of the subject
     optional string subjectPublicKeyRef = 6;
     // The format of the certificate. Examples include X.509, PEM, DER, and CVC.
     optional string certificateFormat = 7;
@@ -2368,17 +2368,17 @@ message CryptoProperties {
     message CryptoRelatedSecuredBy {
       // Specifies the mechanism by which the cryptographic asset is secured. Examples include HSM, TPM, SGX, Software, and None
       optional string mechanism = 1;
-      // The bom-ref to the algorithm.
+      // The bom_ref to the algorithm.
       optional string algorithmRef = 2;
     }
 
     // The type for the related cryptographic material
     optional CryptoRelatedType type = 1;
-    // The optional unique identifier for the related cryptographic material.
+    // The unique identifier for the related cryptographic material.
     optional string id = 2;
     // The key state as defined by NIST SP 800-57.
     optional CryptoRelatedState state = 3;
-    // The bom-ref to the algorithm used to generate the related cryptographic material.
+    // The bom_ref to the algorithm used to generate the related cryptographic material.
     optional string algorithmRef = 4;
     // The date and time (timestamp) when the related cryptographic material was created.
     optional google.protobuf.Timestamp creationDate = 5;
@@ -2425,7 +2425,7 @@ message CryptoProperties {
     message CryptoProtocolCipherSuite {
       // A common name for the cipher suite. For example: TLS_DHE_RSA_WITH_AES_128_CCM
       optional string name = 1;
-      // A list of algorithms related to the cipher suite. Use the bom-ref to the algorithm cryptographic asset.
+      // A list of algorithms related to the cipher suite. Use the bom_ref to the algorithm cryptographic asset.
       repeated string algorithms = 2;
       // A list of common identifiers for the cipher suite. For example: 0xC0 and 0x9E
       repeated string identifiers = 3;
@@ -2455,7 +2455,7 @@ message CryptoProperties {
     repeated CryptoProtocolCipherSuite cipherSuites = 3;
     // The IKEv2 transform types supported (types 1-4), defined in RFC7296 section 3.3.2, and additional properties.
     optional Ikev2TransformTypes ikev2TransformTypes = 4;
-    // The bom-ref(s) to protocol-related cryptographic assets
+    // The bom_ref(s) to protocol-related cryptographic assets
     repeated string cryptoRef = 5;
   } // end of ProtocolProperties
 
@@ -2495,7 +2495,7 @@ message PriorityApplication {
 
 // A patent is a legal instrument, granted by an authority, that confers certain rights over an invention for a specified period, contingent on public disclosure and adherence to relevant legal requirements. The summary information in this object is aligned with [WIPO ST.96](https://www.wipo.int/standards/en/st96/) principles where applicable.
 message Patent {
-  // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 1;
   // The unique number assigned to the granted patent by the issuing authority. Aligned with `PatentNumber` in WIPO ST.96. Refer to [PatentNumber in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentNumber.xsd).
   string patent_number = 2;
@@ -2559,27 +2559,27 @@ enum PatentLegalStatus {
 
 // A patent family is a group of related patent applications or granted patents that cover the same or similar invention. These patents are filed in multiple jurisdictions to protect the invention across different regions or countries. A patent family typically includes patents that share a common priority date, originating from the same initial application, and may vary slightly in scope or claims to comply with regional legal frameworks. Fields align with WIPO ST.96 standards where applicable.
 message PatentFamily {
-  // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 1;
   // The unique identifier for the patent family, aligned with the `id` attribute in WIPO ST.96 v8.0's `PatentFamilyType`. Refer to [PatentFamilyType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentFamilyType.xsd).
   string family_id = 2;
   // The priorityApplication contains the essential data necessary to identify and reference an earlier patent filing for priority rights. In line with WIPO ST.96 guidelines, it includes the jurisdiction (office code), application number, and filing date-the three key elements that uniquely specify the priority application in a global patent context.
   optional PriorityApplication priority_application = 3;
-  // A collection of patents or applications that belong to this family, each identified by a `bom-ref` pointing to a patent object defined elsewhere in the BOM.
-  repeated string members = 4; // bom-ref strings
+  // A collection of patents or applications that belong to this family, each identified by a `bom_ref` pointing to a patent object defined elsewhere in the BOM.
+  repeated string members = 4; // bom_ref strings
   // External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.
   repeated ExternalReference external_references = 5;
 }
 
 // An assertion linking a patent or patent family to this component or service.
 message PatentAssertion {
-  // An optional identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
+  // A identifier which can be used to reference the component elsewhere in the BOM. Uniqueness is enforced within all elements and children of the root-level bom element.
   optional string bom_ref = 1;
   // The type of assertion being made about the patent or patent family. Examples include ownership, licensing, and standards inclusion.
   PatentAssertionType assertion_type = 2;
-  // A list of BOM references (`bom-ref`) linking to patents or patent families associated with this assertion.
+  // A list of BOM references (`bom_ref`) linking to patents or patent families associated with this assertion.
   repeated string patent_refs = 3;
-  // A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom-ref` pointing to one of these objects.
+  // A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom_ref` pointing to one of these objects.
   Asserter asserter = 4;
   // Additional notes or clarifications regarding the assertion, if necessary. For example, geographical restrictions, duration, or limitations of a license.
   string notes = 5;
@@ -2591,7 +2591,7 @@ message Asserter {
     OrganizationalEntity organization = 1;
     // An individual
     OrganizationalContact individual = 2;
-    // A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom-ref` pointing to one of these objects.
+    // A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom_ref` pointing to one of these objects.
     string ref = 3;
   }
 }
@@ -2633,7 +2633,7 @@ message Citation {
     repeated string expression = 1;
   }
 
-  // Optional unique identifier for the citation
+  // Unique identifier for the citation.
   optional string bom_ref = 1;
   // Exactly one of the "pointers" or "expressions" elements must be present.
   oneof target {
@@ -2644,12 +2644,12 @@ message Citation {
   }
   // Timestamp when the attribution was made or the information was supplied.
   google.protobuf.Timestamp timestamp = 4;
-  // The `bom-ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.
+  // The `bom_ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.
   // At least one of the "attributed_to" or "process" elements must be present.
   optional string attributed_to = 5;
-  // The `bom-ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.
+  // The `bom_ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.
   // At least one of the "attributed_to" or "process" elements must be present.
   optional string process = 6;
-  // An optional description or comment about the context or quality of the data attribution.
+  // A description or comment about the context or quality of the data attribution.
   optional string note = 7;
 }

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -121,7 +121,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
               },
               "thirdParty": {
                 "type": "boolean",
@@ -250,7 +250,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
               },
               "target": {
                 "$ref": "#/definitions/refLinkType",
@@ -311,7 +311,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
               },
               "propertyName": {
                 "type": "string",
@@ -345,7 +345,7 @@
                       "properties": {
                         "attachment": {
                           "title": "Data Attachment",
-                          "description": "An optional way to include textual or encoded data.",
+                          "description": "A way to include textual or encoded data.",
                           "$ref": "#/definitions/attachment"
                         },
                         "url": {
@@ -384,7 +384,7 @@
                 "type": "string",
                 "format": "date-time",
                 "title": "Expires",
-                "description": "The optional date and time (timestamp) when the evidence is no longer valid."
+                "description": "The date and time (timestamp) when the evidence is no longer valid."
               },
               "author": {
                 "$ref": "#/definitions/organizationalContact",
@@ -800,7 +800,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "name": {
           "type": "string",
@@ -841,7 +841,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "name": {
           "type": "string",
@@ -912,14 +912,14 @@
         "mime-type": {
           "type": "string",
           "title": "Mime-Type",
-          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "description": "The mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
           "examples": ["image/jpeg"],
           "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
         },
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the component elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "supplier": {
           "title": "Component Supplier",
@@ -1122,7 +1122,7 @@
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
           "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "description": "Specifies release notes."
         },
         "modelCard": {
           "$ref": "#/definitions/modelCard",
@@ -1247,7 +1247,7 @@
         "encoding": {
           "type": "string",
           "title": "Encoding",
-          "description": "Specifies the optional encoding the text is represented in.",
+          "description": "Specifies the encoding the text is represented in.",
           "enum": [
             "base64"
           ],
@@ -1479,7 +1479,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "id": {
           "$ref": "spdx.schema.json",
@@ -1498,7 +1498,7 @@
         },
         "text": {
           "title": "License text",
-          "description": "An optional way to include the textual content of a license.",
+          "description": "A way to include the textual content of a license.",
           "$ref": "#/definitions/attachment"
         },
         "url": {
@@ -1591,11 +1591,11 @@
                     "bom-ref": {
                       "$ref": "#/definitions/refType",
                       "title": "BOM Reference",
-                      "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                      "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
                     },
                     "text": {
                       "title": "License texts",
-                      "description": "An optional way to include the textual content of the license.",
+                      "description": "A way to include the textual content of the license.",
                       "$ref": "#/definitions/attachment"
                     },
                     "url": {
@@ -1617,7 +1617,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
               },
               "licensing": {
                 "$ref": "#/definitions/licensing"
@@ -1716,7 +1716,7 @@
       "properties": {
         "text": {
           "title": "Diff text",
-          "description": "Specifies the optional text of the diff",
+          "description": "Specifies the text of the diff",
           "$ref": "#/definitions/attachment"
         },
         "url": {
@@ -1855,7 +1855,7 @@
         "comment": {
           "type": "string",
           "title": "Comment",
-          "description": "An optional comment describing the external reference"
+          "description": "A comment describing the external reference"
         },
         "type": {
           "type": "string",
@@ -2019,7 +2019,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the service elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "provider": {
           "title": "Provider",
@@ -2103,7 +2103,7 @@
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
           "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "description": "Specifies release notes."
         },
         "properties": {
           "type": "array",
@@ -2265,7 +2265,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                "description": "An identifier which can be used to reference the occurrence elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
               },
               "location": {
                 "type": "string",
@@ -2331,7 +2331,7 @@
                   },
                   "parameters": {
                     "title": "Parameters",
-                    "description": "Optional arguments that are passed to the module or function.",
+                    "description": "Arguments that are passed to the module or function.",
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -2380,7 +2380,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the composition elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "aggregate": {
           "$ref": "#/definitions/aggregateType",
@@ -2600,7 +2600,7 @@
         "title": {
           "type": "string",
           "title": "Title",
-          "description": "An optional name of the advisory."
+          "description": "A name of the advisory."
         },
         "url": {
           "type": "string",
@@ -2740,7 +2740,7 @@
         "justification": {
           "type": "string",
           "title": "Justification",
-          "description": "An optional reason for rating the vulnerability as it was"
+          "description": "A reason for rating the vulnerability as it was"
         }
       }
     },
@@ -2781,7 +2781,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the vulnerability elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "id": {
           "type": "string",
@@ -3163,7 +3163,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the annotation elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "subjects": {
           "type": "array",
@@ -3257,7 +3257,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the model card elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "modelParameters": {
           "type": "object",
@@ -3461,7 +3461,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An identifier which can be used to reference the dataset elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "type": {
           "type": "string",
@@ -3495,7 +3495,7 @@
           "properties": {
             "attachment": {
               "title": "Data Attachment",
-              "description": "An optional way to include textual or encoded data.",
+              "description": "A way to include textual or encoded data.",
               "$ref": "#/definitions/attachment"
             },
             "url": {
@@ -3871,7 +3871,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the energy provider elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the energy provider elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "description": {
@@ -3937,7 +3937,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the address elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "country": {
@@ -3985,7 +3985,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the formula elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the formula elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "components": {
@@ -4040,7 +4040,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workflow elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the workflow elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "uid": {
@@ -4184,7 +4184,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the task elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the task elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "uid": {
@@ -4359,7 +4359,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workspace elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the workspace elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "uid": {
@@ -4508,7 +4508,7 @@
       "properties": {
         "bom-ref": {
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the trigger elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "description": "An identifier which can be used to reference the trigger elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
           "$ref": "#/definitions/refType"
         },
         "uid": {
@@ -5044,7 +5044,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
         },
         "name": {
           "type": "string",
@@ -5078,7 +5078,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
               },
               "identifier": {
                 "type": "string",
@@ -5114,7 +5114,7 @@
               "parent": {
                 "$ref": "#/definitions/refLinkType",
                 "title": "Parent BOM Reference",
-                "description": "The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
+                "description": "The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
               },
               "properties": {
                 "type": "array",
@@ -5145,7 +5145,7 @@
               "bom-ref": {
                 "$ref": "#/definitions/refType",
                 "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
               },
               "identifier": {
                 "type": "string",
@@ -5589,7 +5589,7 @@
             "id": {
               "type": "string",
               "title": "ID",
-              "description": "The optional unique identifier for the related cryptographic material."
+              "description": "The unique identifier for the related cryptographic material."
             },
             "state": {
               "type": "string",
@@ -5853,7 +5853,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref MUST be unique within the BOM. \n\nFor a patent, it might be a good idea to use a patent number as the BOM reference ID."
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM. \n\nFor a patent, it might be a good idea to use a patent number as the BOM reference ID."
         },
         "familyId": {
           "type": "string",
@@ -5893,7 +5893,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
         },
         "patentNumber": {
           "type": "string",
@@ -6166,12 +6166,12 @@
         "note": {
           "type": "string",
           "title": "Note",
-          "description": "An optional description or comment about the context or quality of the data attribution."
+          "description": "A description or comment about the context or quality of the data attribution."
         },
         "signature": {
           "$ref": "#/definitions/signature",
           "title": "Signature",
-          "description": "An optional digital signature verifying the authenticity or integrity of the attribution."
+          "description": "A digital signature verifying the authenticity or integrity of the attribution."
         }
       },
       "required": ["timestamp"],

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -383,7 +383,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -518,7 +518,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -767,7 +767,7 @@ limitations under the License.
             </xs:element>
             <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                    <xs:documentation>Specifies release notes.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="modelCard" type="bom:modelCardType" minOccurs="0" maxOccurs="1">
@@ -817,7 +817,7 @@ limitations under the License.
         <xs:attribute name="mime-type" type="bom:mimeType">
             <xs:annotation>
                 <xs:documentation>
-                    The optional mime-type of the component. When used on file components, the mime-type
+                    The mime-type of the component. When used on file components, the mime-type
                     can provide additional context about the kind of file being represented such as an image,
                     font, or executable. Some library or framework components may also have an associated mime-type.
                 </xs:documentation>
@@ -835,7 +835,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the component elsewhere in the BOM.
+                    An identifier which can be used to reference the component elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -860,7 +860,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the license elsewhere in the BOM.
+                    An identifier which can be used to reference the license elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -1026,7 +1026,7 @@ limitations under the License.
             </xs:choice>
             <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Specifies the optional full text of the attachment</xs:documentation>
+                    <xs:documentation>Specifies the full text of the attachment</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
@@ -1101,7 +1101,7 @@ limitations under the License.
                     <xs:sequence>
                         <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
-                                <xs:documentation>An optional way to include the textual content of the license.</xs:documentation>
+                                <xs:documentation>A way to include the textual content of the license.</xs:documentation>
                             </xs:annotation>
                         </xs:element>
                         <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
@@ -1134,7 +1134,7 @@ limitations under the License.
                     <xs:attribute name="bom-ref" type="bom:refType">
                         <xs:annotation>
                             <xs:documentation>
-                                An optional identifier which can be used to reference the license elsewhere in the BOM.
+                                An identifier which can be used to reference the license elsewhere in the BOM.
                                 Uniqueness is enforced within all elements and children of the root-level bom element.
                             </xs:documentation>
                         </xs:annotation>
@@ -1200,7 +1200,7 @@ limitations under the License.
                 <xs:attribute name="encoding" type="bom:encoding">
                     <xs:annotation>
                         <xs:documentation>
-                            Specifies the optional encoding the text is represented in
+                            Specifies the encoding the text is represented in
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -1829,7 +1829,7 @@ limitations under the License.
             </xs:element>
             <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation xml:lang="en">An optional comment describing the external reference</xs:documentation>
+                    <xs:documentation xml:lang="en">A comment describing the external reference</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="hashes" minOccurs="0" maxOccurs="1">
@@ -2030,7 +2030,7 @@ limitations under the License.
         <xs:sequence>
             <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation xml:lang="en">Specifies the optional text of the diff</xs:documentation>
+                    <xs:documentation xml:lang="en">Specifies the text of the diff</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
@@ -2483,7 +2483,7 @@ limitations under the License.
             </xs:element>
             <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                    <xs:documentation>Specifies release notes.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
@@ -2498,7 +2498,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the service elsewhere in the BOM.
+                    An identifier which can be used to reference the service elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -2805,8 +2805,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the occurrence elsewhere
-                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                            An identifier which can be used to reference the occurrence elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -2849,7 +2849,7 @@ limitations under the License.
                                                 </xs:element>
                                                 <xs:element name="parameters" minOccurs="0" maxOccurs="1">
                                                     <xs:annotation>
-                                                        <xs:documentation>Optional arguments that are passed to the module or function.</xs:documentation>
+                                                        <xs:documentation>Arguments that are passed to the module or function.</xs:documentation>
                                                     </xs:annotation>
                                                     <xs:complexType>
                                                         <xs:sequence>
@@ -3011,7 +3011,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the composition elsewhere in the BOM.
+                    An identifier which can be used to reference the composition elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -3619,8 +3619,8 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the model card elsewhere in the BOM.
-                    Every bom-ref must be unique within the BOM.
+                    An identifier which can be used to reference the model card elsewhere in the BOM.
+                    Every `bom-ref` must be unique within the BOM.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -3991,7 +3991,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the energy provider elsewhere in the BOM.
+                    An identifier which can be used to reference the energy provider elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -4051,7 +4051,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the address elsewhere in the BOM.
+                    An identifier which can be used to reference the address elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -4135,7 +4135,7 @@ limitations under the License.
                     <xs:sequence>
                         <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
-                                <xs:documentation>An optional way to include textual or encoded data.</xs:documentation>
+                                <xs:documentation>A way to include textual or encoded data.</xs:documentation>
                             </xs:annotation>
                         </xs:element>
                         <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
@@ -4185,8 +4185,8 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the dataset elsewhere in the BOM.
-                    Every bom-ref must be unique within the BOM.
+                    An identifier which can be used to reference the dataset elsewhere in the BOM.
+                    Every `bom-ref` must be unique within the BOM.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -4741,7 +4741,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the vulnerability elsewhere in the BOM.
+                    An identifier which can be used to reference the vulnerability elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -4796,7 +4796,7 @@ limitations under the License.
             </xs:element>
             <xs:element name="justification" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>An optional reason for rating the vulnerability as it was.</xs:documentation>
+                    <xs:documentation>A reason for rating the vulnerability as it was.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
@@ -4806,7 +4806,7 @@ limitations under the License.
         <xs:sequence>
             <xs:element name="title" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>An optional name of the advisory.</xs:documentation>
+                    <xs:documentation>A name of the advisory.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="url" type="xs:anyURI" minOccurs="1" maxOccurs="1">
@@ -4909,7 +4909,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the annotation elsewhere in the BOM.
+                    An identifier which can be used to reference the annotation elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -5288,7 +5288,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the formula elsewhere in the BOM.
+                    An identifier which can be used to reference the formula elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -5456,7 +5456,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the workflow elsewhere in the BOM.
+                    An identifier which can be used to reference the workflow elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -5678,7 +5678,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the task elsewhere in the BOM.
+                    An identifier which can be used to reference the task elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -5881,7 +5881,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the workflow elsewhere in the BOM.
+                    An identifier which can be used to reference the workflow elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -6202,7 +6202,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the trigger elsewhere in the BOM.
+                    An identifier which can be used to reference the trigger elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -7361,7 +7361,7 @@ limitations under the License.
                         <xs:element name="id" type="xs:string" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>
-                                    The optional unique identifier for the related cryptographic material.
+                                    The unique identifier for the related cryptographic material.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
@@ -7717,8 +7717,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the object elsewhere in the BOM.
-                                            Every bom-ref must be unique within the BOM.
+                                            An identifier which can be used to reference the object elsewhere in the BOM.
+                                            Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -7984,8 +7984,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the object elsewhere
-                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -8055,7 +8055,7 @@ limitations under the License.
                                                         <xs:sequence>
                                                             <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
                                                                 <xs:annotation>
-                                                                    <xs:documentation>An optional way to include textual or encoded data.</xs:documentation>
+                                                                    <xs:documentation>A way to include textual or encoded data.</xs:documentation>
                                                                 </xs:annotation>
                                                             </xs:element>
                                                             <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
@@ -8091,7 +8091,7 @@ limitations under the License.
                                     </xs:element>
                                     <xs:element name="expires" type="xs:dateTime" minOccurs="0">
                                         <xs:annotation>
-                                            <xs:documentation>The optional date and time (timestamp) when the evidence is no longer valid.</xs:documentation>
+                                            <xs:documentation>The date and time (timestamp) when the evidence is no longer valid.</xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
                                     <xs:element name="author" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
@@ -8115,8 +8115,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the object elsewhere
-                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                            A identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -8407,7 +8407,7 @@ limitations under the License.
                                     <xs:element name="parent" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
                                         <xs:annotation>
                                             <xs:documentation>
-                                                The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
+                                                The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
@@ -8431,8 +8431,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the object elsewhere
-                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -8495,8 +8495,8 @@ limitations under the License.
                                 <xs:attribute name="bom-ref" type="bom:refType">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            An optional identifier which can be used to reference the object elsewhere
-                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -8528,8 +8528,8 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere
-                    in the BOM. Every bom-ref must be unique within the BOM.
+                    An identifier which can be used to reference the object elsewhere
+                    in the BOM. Every `bom-ref` must be unique within the BOM.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -8589,7 +8589,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -8677,7 +8677,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -8733,7 +8733,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>
@@ -8959,7 +8959,7 @@ limitations under the License.
             <xs:element name="note" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        An optional description or comment about the context or quality of the data attribution.
+                        An description or comment about the context or quality of the data attribution.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -8982,7 +8982,7 @@ limitations under the License.
         <xs:attribute name="bom-ref" type="bom:refType" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    An identifier which can be used to reference the object elsewhere in the BOM.
                     Uniqueness is enforced within all elements and children of the root-level bom element.
                 </xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
removed the word "optional" whenever possible, as the schemas clearly tell when something is optional or required.
as agreed in https://github.com/CycloneDX/specification/issues/616#issuecomment-2761792157 and https://github.com/CycloneDX/specification/issues/649#issuecomment-2964680048

- fixes #616
- fixes #649