### PR TITLE
Adds support for post-quantum ML-DSA algorithms

### DIFF
--- a/schema/jsf-0.82.schema.json
+++ b/schema/jsf-0.82.schema.json
@@ -3,7 +3,7 @@
   "$id": "http://cyclonedx.org/schema/jsf-0.82.schema.json",
   "type": "object",
   "title": "JSON Signature Format (JSF) standard",
-  "$comment" : "JSON Signature Format schema is published under the terms of the Apache License 2.0. JSF was developed by Anders Rundgren (anders.rundgren.net@gmail.com) as a part of the OpenKeyStore project. This schema supports the entirely of the JSF standard excluding 'extensions'.",
+  "$comment" : "JSON Signature Format schema is published under the terms of the Apache License 2.0. JSF was developed by Anders Rundgren (anders.rundgren.net@gmail.com) as a part of the OpenKeyStore project. This schema extends the JSF standard to include post-quantum algorithms (ML-DSA) following NIST FIPS 204, excluding 'extensions'.",
   "definitions": {
     "signature": {
       "type": "object",
@@ -15,7 +15,7 @@
             "signers": {
               "type": "array",
               "title": "Signature",
-              "description": "Unique top level property for Multiple Signatures. (multisignature)",
+              "description": "Unique top level property for Multiple Signatures. (multisignature). Can include both classical and post-quantum signatures.",
               "items": {"$ref": "#/definitions/signer"}
             }
           }
@@ -26,14 +26,14 @@
             "chain": {
               "type": "array",
               "title": "Signature",
-              "description": "Unique top level property for Signature Chains. (signaturechain)",
+              "description": "Unique top level property for Signature Chains. (signaturechain). Chain can include both classical and post-quantum signatures following NIST FIPS 204 standards.",
               "items": {"$ref": "#/definitions/signer"}
             }
           }
         },
         {
           "title": "Signature",
-          "description": "Unique top level property for simple signatures. (signaturecore)",
+          "description": "Unique top level property for simple signatures. (signaturecore). Supports both classical and post-quantum algorithms including ML-DSA variants.",
           "$ref": "#/definitions/signer"
         }
       ]
@@ -52,7 +52,7 @@
             {
               "type": "string",
               "title": "Algorithm",
-              "description": "Signature algorithm. The currently recognized JWA [RFC7518] and RFC8037 [RFC8037] asymmetric key algorithms. Note: Unlike RFC8037 [RFC8037] JSF requires explicit Ed* algorithm names instead of \"EdDSA\".",
+              "description": "Signature algorithm. The currently recognized JWA [RFC7518] and RFC8037 [RFC8037] asymmetric key algorithms, plus post-quantum algorithms. Note: Unlike RFC8037 [RFC8037] JSF requires explicit Ed* algorithm names instead of \"EdDSA\". Three post-quantum ML-DSA algorithms have been added following NIST FIPS 204 standardization.",
               "enum": [
                 "RS256",
                 "RS384",
@@ -67,7 +67,10 @@
                 "Ed448",
                 "HS256",
                 "HS384",
-                "HS512"
+                "HS512",
+                "ML-DSA-44",
+                "ML-DSA-65",
+                "ML-DSA-87"  
               ]
             },
             {
@@ -81,17 +84,17 @@
         "keyId": {
           "type": "string",
           "title": "Key ID",
-          "description": "Optional. Application specific string identifying the signature key."
+          "description": "Optional. Application specific string identifying the signature key. Can reference both classical and post-quantum keys."
         },
         "publicKey": {
           "title": "Public key",
-          "description": "Optional. Public key object.",
+          "description": "Optional. Public key object. Supports classical key types (EC, RSA, OKP) and post-quantum key types (PQ) for ML-DSA algorithms.",
           "$ref": "#/definitions/publicKey"
         },
         "certificatePath": {
           "type": "array",
           "title": "Certificate path",
-          "description": "Optional. Sorted array of X.509 [RFC5280] certificates, where the first element must contain the signature certificate. The certificate path must be contiguous but is not required to be complete.",
+          "description": "Optional. Sorted array of X.509 [RFC5280] certificates, where the first element must contain the signature certificate. The certificate path must be contiguous but is not required to be complete. Certificates may contain post-quantum public keys following NIST standards.",
           "items": {
             "type": "string"
           }
@@ -99,7 +102,7 @@
         "excludes": {
           "type": "array",
           "title": "Excludes",
-          "description": "Optional. Array holding the names of one or more application level properties that must be excluded from the signature process. Note that the \"excludes\" property itself, must also be excluded from the signature process. Since both the \"excludes\" property and the associated data it points to are unsigned, a conforming JSF implementation must provide options for specifying which properties to accept.",
+          "description": "Optional. Array holding the names of one or more application level properties that must be excluded from the signature process. Note that the \"excludes\" property itself, must also be excluded from the signature process. Since both the \"excludes\" property and the associated data it points to are unsigned, a conforming JSF implementation must provide options for specifying which properties to accept. This applies to both classical and post-quantum signatures.",
           "items": {
             "type": "string"
           }
@@ -107,23 +110,24 @@
         "value": {
           "type": "string",
           "title": "Signature",
-          "description": "The signature data. Note that the binary representation must follow the JWA [RFC7518] specifications."
+          "description": "The signature data encoded as base64url without padding. Encoding standards: (1) Classical algorithms (RS256, ES256, Ed25519, etc.): Follow JWA [RFC7518] specifications for signature serialization. (2) Post-quantum algorithms (ML-DSA-44, ML-DSA-65, ML-DSA-87): Follow NIST FIPS 204 standard for ML-DSA signature encoding."
         }
       }
     },
     "keyType": {
       "type": "string",
       "title": "Key type",
-      "description": "Key type indicator.",
+      "description": "Key type indicator. 'PQ' indicates post-quantum algorithms following NIST FIPS 204 standards, specifically ML-DSA algorithms.",
       "enum": [
         "EC",
         "OKP",
-        "RSA"
+        "RSA",
+        "PQ"
       ]
     },
     "publicKey": {
       "title": "Public key",
-      "description": "Optional. Public key object.",
+      "description": "Optional. Public key object. Supports classical key types (EC, RSA, OKP) and post-quantum key types (PQ) for ML-DSA algorithms.",
       "type": "object",
       "required": [
         "kty"
@@ -230,6 +234,39 @@
                 "type": "string",
                 "title": "Exponent",
                 "description": "RSA exponent."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "kty": { "const": "PQ" } }
+          },
+          "then": {
+            "required": [
+              "kty",
+              "alg",
+              "x"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "kty": {
+                "$ref": "#/definitions/keyType"
+              },
+              "alg": {
+                "type": "string",
+                "title": "Algorithm",
+                "description": "Post-quantum algorithm identifier.",
+                "enum": [
+                  "ML-DSA-44",
+                  "ML-DSA-65", 
+                  "ML-DSA-87"
+                ]
+              },
+              "x": {
+                "type": "string",
+                "title": "Public Key",
+                "description": "ML-DSA public key data encoded as base64url without padding, following NIST FIPS 204 specification for the corresponding algorithm variant."
               }
             }
           }


### PR DESCRIPTION
<!-- 
Thank you for taking the time to develop and contribute a core enhancement or fix for a defect!

We kindly request that you create pull requests only for things that have been discussed in a ticket first; exceptions may be made for spelling or grammar fixes.
Read more about the process here: https://cyclonedx.org/participate/standardization-process/#working-model

Please have the related ticket/issue ID ready. 
If there is none, feel free to create a new ticket: https://github.com/CycloneDX/specification/issues/new/choose

-->
Fixes https://github.com/CycloneDX/specification/issues/674

With inspiration from the Node.js [PRs](https://github.com/nodejs/node/pull/59259) and [this](https://github.com/nodejs/node/pull/59461), this pull request adds three new post-quantum algorithms: "ML-DSA-44", "ML-DSA-65", and "ML-DSA-87" to better future-proof BOM signature validity. The hypothetical but real threat this addresses is that traditional signatures with RSA/ECDSA may become invalid when quantum computers break them.

<!-- 

Please provide a brief description of what this pull request intends to do and which ticket it fixes/closes.  
Example: 
> As discussed in ticket #485, this PR adds Streebog to the hash algorithm enum.
>
> fixes #485 

In case this is for a spelling or grammar improvement, please provide a brief description.
Example:
> Fixe typo: color(AE) -> colour(BE)

-->

Following alternative ideas could be considered:

1. URI-Based references

```"algorithm": "urn:nist.gov:fips204:ml-dsa-44"``` instead of simple upper case enum strings. This however is a significant breaking change to replace all existing identifiers in use.

2. Extend `signer` definition

Signature object support `signer` as one of the types. A new type called `postQuantumSigner` could be created to extend ` signer` to capture additional attributes related to PQ algorithms and also to support a broad range of PQ algorithms.

```
"properties": {
            "signers": {
              "type": "array",
              "title": "Signature",
              "description": "Unique top level property for Multiple Signatures. (multisignature)",
              "items": {"$ref": "#/definitions/signer"}
            }
          }
```

3. Enable additional properties

Currently, additional properties are disabled for signer. To increase flexibility, this could be enabled.

This PR proposes a simple enhancement to the enum, key type indicators, and validation, making this feature >= 1.7 only without any possibility for backports.

TBD:

Enhancing CBOM to support the corresponding OID values.

| Algorithm   | OID                          |
|-------------|------------------------------|
| ml-dsa-44   | 2.16.840.1.101.3.4.3.17      |
| ml-dsa-65   | 2.16.840.1.101.3.4.3.18      |
| ml-dsa-87   | 2.16.840.1.101.3.4.3.19      |
