### PR TITLE
docs: update link to version-range-spec

### DIFF
--- a/schema/bom-1.4.proto
+++ b/schema/bom-1.4.proto
@@ -662,7 +662,7 @@ message VulnerabilityAffectedVersions {
   oneof choice {
     // A single version of a component or service.
     string version = 1;
-    // A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+    // A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
     string range = 2;
   }
   // The vulnerability status for the version or range of versions.

--- a/schema/bom-1.4.schema.json
+++ b/schema/bom-1.4.schema.json
@@ -1640,7 +1640,7 @@
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
                       "$ref": "#/definitions/range"
                     },
                     "status": {
@@ -1683,7 +1683,7 @@
       "maxLength": 1024
     },
     "range": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
       "type": "string",
       "minLength": 1,
       "maxLength": 1024

--- a/schema/bom-1.4.xsd
+++ b/schema/bom-1.4.xsd
@@ -1993,7 +1993,7 @@ limitations under the License.
                                                                 </xs:element>
                                                                 <xs:element name="range" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
                                                                     <xs:annotation>
-                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst</xs:documentation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                             </xs:choice>

--- a/schema/bom-1.5.proto
+++ b/schema/bom-1.5.proto
@@ -960,7 +960,7 @@ message VulnerabilityAffectedVersions {
   oneof choice {
     // A single version of a component or service.
     string version = 1;
-    // A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+    // A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
     string range = 2;
   }
   // The vulnerability status for the version or range of versions. Defaults to VULNERABILITY_AFFECTED_STATUS_AFFECTED if not specified.

--- a/schema/bom-1.5.schema.json
+++ b/schema/bom-1.5.schema.json
@@ -2284,7 +2284,7 @@
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
                       "$ref": "#/definitions/range"
                     },
                     "status": {
@@ -2326,7 +2326,7 @@
       "maxLength": 1024
     },
     "range": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
       "type": "string",
       "minLength": 1,
       "maxLength": 1024

--- a/schema/bom-1.5.xsd
+++ b/schema/bom-1.5.xsd
@@ -3644,7 +3644,7 @@ limitations under the License.
                                                                 </xs:element>
                                                                 <xs:element name="range" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
                                                                     <xs:annotation>
-                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst</xs:documentation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                             </xs:choice>

--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -1093,7 +1093,7 @@ message VulnerabilityAffectedVersions {
   oneof choice {
     // A single version of a component or service.
     string version = 1;
-    // A version range specified in Package URL Version Range syntax (vers), which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+    // A version range specified in Package URL Version Range syntax (vers), which is defined at https://github.com/package-url/vers-spec
     string range = 2;
   }
   // The vulnerability status for the version or range of versions. Defaults to VULNERABILITY_AFFECTED_STATUS_AFFECTED if not specified.

--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -2928,7 +2928,7 @@
                     },
                     "range": {
                       "title": "Version Range",
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
                       "$ref": "#/definitions/versionRange"
                     },
                     "status": {
@@ -2983,7 +2983,7 @@
       ]
     },
     "versionRange": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
       "type": "string",
       "minLength": 1,
       "maxLength": 4096,

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -76,7 +76,7 @@ limitations under the License.
     <xs:simpleType name="versionRangeType">
         <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
-                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
 
                 Example values:
                 - "vers:cargo/9.0.14"
@@ -4475,7 +4475,7 @@ limitations under the License.
                                                                 </xs:element>
                                                                 <xs:element name="range" type="bom:versionRangeType" minOccurs="1" maxOccurs="1">
                                                                     <xs:annotation>
-                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst</xs:documentation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                             </xs:choice>


### PR DESCRIPTION
version-range-spec has been moved. 
- see <https://github.com/package-url/purl-spec/commit/9ecf0febe8bca87ac755490e5f8c731cfbe6e193>  
  > The file `purl-spec/VERSION-RANGE-SPEC.rst` has been moved to https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.rst. The https://github.com/package-url/vers-spec/ repository is also the home for any Issues, PRs, Discussions or other files related to VERS.
- see <https://github.com/package-url/vers-spec/commit/bdb4cdbddd8c3508232d46f60fb7ed76f0e44796>  
  moved https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.rst to https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.md
  

this PR adjust existing doc's links and references:  link to the new vers-specrepo

