### PR TITLE
[1.7] docs: update link to version-range-spec

### DIFF
--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -116,7 +116,7 @@ message Component {
   // Must be used exclusively, either 'version' or 'versionRange', but not both.
   string version = 9;
   // For an external component, this specifies the accepted version range.
-  // The value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst.
+  // The value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/vers-spec.
   // May only be used if `isExternal` is set to `true`.
   // Must be used exclusively, either 'version' or 'versionRange', but not both.
   optional string versionRange = 33;
@@ -1195,7 +1195,7 @@ message VulnerabilityAffectedVersions {
   oneof choice {
     // A single version of a component or service.
     string version = 1;
-    // A version range specified in Package URL Version Range syntax (vers), which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+    // A version range specified in Package URL Version Range syntax (vers), which is defined at https://github.com/package-url/vers-spec
     string range = 2;
   }
   // The vulnerability status for the version or range of versions. Defaults to VULNERABILITY_AFFECTED_STATUS_AFFECTED if not specified.

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -981,7 +981,7 @@
         "versionRange": {
           "$ref": "#/definitions/versionRange",
           "title": "Component Version Range",
-          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at <https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst>.\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at <https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
         },
         "isExternal": {
           "type": "boolean",
@@ -3089,7 +3089,7 @@
                     },
                     "range": {
                       "title": "Version Range",
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
                       "$ref": "#/definitions/versionRange"
                     },
                     "status": {
@@ -3144,7 +3144,7 @@
       ]
     },
     "versionRange": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst",
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
       "type": "string",
       "minLength": 1,
       "maxLength": 4096,

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -76,7 +76,7 @@ limitations under the License.
     <xs:simpleType name="versionRangeType">
         <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
-                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst
+                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
 
                 Example values:
                 - "vers:cargo/9.0.14"
@@ -634,7 +634,7 @@ limitations under the License.
                     <xs:annotation>
                         <xs:documentation><![CDATA[
                         For an external component, this specifies the accepted version range.
-                        The value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst.
+                        The value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/vers-spec.
                         May only be used if `@isExternal` is set to `true`.
                         ]]></xs:documentation>
                     </xs:annotation>
@@ -4718,7 +4718,7 @@ limitations under the License.
                                                                 </xs:element>
                                                                 <xs:element name="range" type="bom:versionRangeType" minOccurs="1" maxOccurs="1">
                                                                     <xs:annotation>
-                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst</xs:documentation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                             </xs:choice>


### PR DESCRIPTION
version-range-spec has been moved. 
- see <https://github.com/package-url/purl-spec/commit/9ecf0febe8bca87ac755490e5f8c731cfbe6e193>  
  > The file `purl-spec/VERSION-RANGE-SPEC.rst` has been moved to https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.rst. The https://github.com/package-url/vers-spec/ repository is also the home for any Issues, PRs, Discussions or other files related to VERS.
- see <https://github.com/package-url/vers-spec/commit/bdb4cdbddd8c3508232d46f60fb7ed76f0e44796>  
  moved https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.rst to https://github.com/package-url/vers-spec/blob/main/VERSION-RANGE-SPEC.md
  


this PR adjust existing doc's links and references: link to the new vers-specrepo 

----

- 1.7 version of #699

