### PR TITLE
Editorial: Fix typos in descriptions

### DIFF
--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -981,7 +981,7 @@
         "versionRange": {
           "$ref": "#/definitions/versionRange",
           "title": "Component Version Range",
-          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at <https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
         },
         "isExternal": {
           "type": "boolean",
@@ -1103,7 +1103,7 @@
             "patches": {
               "type": "array",
               "title": "Patches",
-              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+              "description": "A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
               "items": {"$ref": "#/definitions/patch"}
             },
             "notes": {


### PR DESCRIPTION
A couple of errant characters in their description fields are rendering and should not be. Editors' discretion if they'd rather add a > than remove a <