### PR TITLE
fix(registry): correct TUAK naming and bcrypt pattern syntax

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -1018,11 +1018,11 @@
       ],
       "variant": [
         {
-          "pattern": "TUAC[-MAC]",
+          "pattern": "TUAK[-MAC]",
           "primitive": "mac"
         },
         {
-          "pattern": "TUAC[-KDF]",
+          "pattern": "TUAK[-KDF]",
           "primitive": "kdf"
         }
       ]
@@ -1407,7 +1407,7 @@
       ],
       "variant": [
         {
-          "pattern": "bcrypt[-{cost)]",
+          "pattern": "bcrypt[-{cost}]",
           "primitive": "hash"
         }
       ]


### PR DESCRIPTION
As discussed in ticket #750, this PR fixes data-quality issues in the Cryptography Registry.

Fixes #750

### Details
- Fixes malformed bcrypt pattern optional parameter syntax (`bcrypt[-{cost)]` → `bcrypt[-{cost}]`)
- Corrects TUAK algorithm family naming (previously listed as TUAC for MAC and KDF variants)
