### PR TITLE
feat(registry): add XChaCha20-Poly1305 AEAD variant

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -468,6 +468,10 @@
         {
           "pattern": "ChaCha20-Poly1305",
           "primitive": "ae"
+        },
+        {
+          "pattern": "XChaCha20-Poly1305",
+          "primitive": "ae"
         }
       ]
     },


### PR DESCRIPTION
As discussed in ticket #754, this PR adds XChaCha20-Poly1305 as an AEAD variant to the Cryptography Registry.

Fixes #754

### Details
- Adds `XChaCha20-Poly1305` as an `ae` variant under the existing `ChaCha20` family

### Scope
- Cryptography Registry data only (`schema/cryptography-defs.json`)
- No schema or specification behavior changes
