### PR TITLE
Feat/crypto registry aes gcm siv

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -356,6 +356,16 @@
         {
           "standard": [
             {
+              "name": "RFC8452",
+              "url": "https://doi.org/10.17487/RFC8452"
+            }
+          ],
+          "pattern": "AES[-(128|192|256)]-GCM-SIV[-{tagLength}][-{ivLength}]",
+          "primitive": "ae"
+        },
+        {
+          "standard": [
+            {
               "name": "RFC3686",
               "url": "https://doi.org/10.17487/RFC3686"
             }


### PR DESCRIPTION
As discussed in ticket #758, this PR adds AES-GCM-SIV as an AEAD variant to the Cryptography Registry.

Fixes #758

### Details
- Adds standardized AES-GCM-SIV (RFC 8452) as an `ae` variant under the existing AES family

### Scope
- Registry data only (`schema/cryptography-defs.json`)
- No schema or specification behavior changes
