### PR TITLE
feat(registry): add AES-SIV AEAD variant (RFC 5297)

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -366,6 +366,16 @@
         {
           "standard": [
             {
+              "name": "RFC 5297",
+              "url": "https://doi.org/10.17487/RFC5297"
+            }
+          ],
+          "pattern": "AES[-(128|192|256)]-SIV",
+          "primitive": "ae"
+        },
+        {
+          "standard": [
+            {
               "name": "RFC5649",
               "url": "https://doi.org/10.17487/RFC5649"
             }


### PR DESCRIPTION
As discussed in ticket #763, this PR adds AES-SIV (RFC 5297) as an AEAD variant to the Cryptography Registry.

Fixes #763

Details
- Adds `AES[-(128|192|256)]-SIV` as an `ae` variant under the existing `AES` family.
- Adds authoritative standards reference for RFC 5297.
- Registry-only change (`schema/cryptography-defs.json`). No schema or specification behavior changes.