### PR TITLE
feat(registry): add HPKE (RFC 9180) to Cryptography Registry

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -137,7 +137,7 @@
           "primitive": "pke"
         }
       ]
-    },    
+    },
     {
       "family": "MQV",
       "standard": [


### PR DESCRIPTION
As discussed in ticket #765, this PR adds HPKE (RFC 9180) to the Cryptography Registry.

Fixes #765

Details
- Adds the HPKE algorithm family with pattern `HPKE[-{mode}]-{kem}-{kdf}-{aead}` (primitive: `pke`).
- Adds RFC 9180 as the authoritative reference.
- Updates the registry schema enum to allow `HPKE`.

Scope
- Registry-only (`schema/cryptography-defs.json`) plus corresponding registry schema update (`schema/cryptography-defs.schema.json`).
- No CycloneDX specification behavior changes.