### PR TITLE
fix(proto): correct 'plain text' typo in AttachedText comment

### DIFF
--- a/schema/bom-1.6.proto
+++ b/schema/bom-1.6.proto
@@ -4,7 +4,7 @@ import "google/protobuf/timestamp.proto";
 
 // Specifies attributes of the text
 message AttachedText {
-  // Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents. [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
+  // Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plain text documents. [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
   optional string content_type = 1;
   // Specifies the optional encoding the text is represented in
   optional string encoding = 2;

--- a/schema/bom-1.7.proto
+++ b/schema/bom-1.7.proto
@@ -4,7 +4,7 @@ import "google/protobuf/timestamp.proto";
 
 // Specifies attributes of the text
 message AttachedText {
-  // Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents. [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
+  // Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plain text documents. [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
   optional string content_type = 1;
   // Specifies the encoding the text is represented in
   optional string encoding = 2;


### PR DESCRIPTION
Corrects a typo in Protocol Buffers schema documentation: "plan text" -> "plain text" for the  example.

Closes #785.