### PR TITLE
feat(registry): add SPAKE2 (RFC 9382) and SPAKE2+ (RFC 9383)

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -1048,6 +1048,36 @@
       ]
     },
     {
+      "family": "SPAKE2",
+      "standard": [
+        {
+          "name": "RFC9382",
+          "url": "https://doi.org/10.17487/RFC9382"
+        }
+      ],
+      "variant": [
+        {
+          "pattern": "SPAKE2[-{group}][-{hashFunction}][-{kdf}][-{mac}]",
+          "primitive": "key-agree"
+        }
+      ]
+    },
+    {
+      "family": "SPAKE2PLUS",
+      "standard": [
+        {
+          "name": "RFC9383",
+          "url": "https://doi.org/10.17487/RFC9383"
+        }
+      ],
+      "variant": [
+        {
+          "pattern": "SPAKE2+[-{group}][-{hashFunction}][-{kdf}][-{mac}]",
+          "primitive": "key-agree"
+        }
+      ]
+    },
+    {
       "family": "TUAK",
       "standard": [
         {


### PR DESCRIPTION
## Summary
Add SPAKE2 (RFC 9382) and SPAKE2+ (RFC 9383) to `schema/cryptography-defs.json`.

## References
- Issue: #797
- RFC 9382: https://doi.org/10.17487/RFC9382
- RFC 9383: https://doi.org/10.17487/RFC9383

## Change
- Add `family: SPAKE2` with variants:
  - `SPAKE2`
  - `SPAKE2[-{group}][-{hashFunction}][-{kdf}][-{mac}]`
- Add `family: SPAKE2PLUS` (represents SPAKE2+) with variants:
  - `SPAKE2+`
  - `SPAKE2+[-{group}][-{hashFunction}][-{kdf}][-{mac}]`

Notes:
- `family` uses `SPAKE2PLUS` (no `+`) to match existing registry naming constraints, while `pattern` preserves the canonical protocol name `SPAKE2+` from RFC 9383.
- Entries are placed in alphabetical order within `algorithms[]`.

## Validation
- `python3 -m json.tool schema/cryptography-defs.json` (JSON OK)
