### PR TITLE
fix(registry): correct SP800-185 reference URL

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -276,7 +276,7 @@
         },
         {
           "name": "SP800-185",
-          "url": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf"
+          "url": "https://doi.org/10.6028/NIST.SP.800-185"
         }
       ],
       "variant": [
@@ -974,11 +974,11 @@
           "primitive": "hash"
         },
         {
-          "pattern": "BLAKE2b-(160|256|384|512)-HMAC",
+          "pattern": "BLAKE2s-(160|256)-HMAC",
           "primitive": "mac"
         }
       ]
-    },
+    }, 
     {
       "family": "BLAKE3",
       "standard": [


### PR DESCRIPTION
Fixes #802. Updates SP800-185 reference under SHA-3 to https://doi.org/10.6028/NIST.SP.800-185.