### PR TITLE
Add HPKE to algorithmFamiliesEnum

### DIFF
--- a/schema/cryptography-defs.schema.json
+++ b/schema/cryptography-defs.schema.json
@@ -270,6 +270,7 @@
         "FFDH",
         "Fortuna",
         "GOST",
+        "HPKE",
         "HC",
         "HKDF",
         "HMAC",


### PR DESCRIPTION
Fixes #809

HPKE is defined in `schema/cryptography-defs.json` but missing from `schema/cryptography-defs.schema.json#/definitions/algorithmFamiliesEnum`. BOM 1.7 validates `cryptoProperties.algorithmProperties.algorithmFamily` against this enum, so valid HPKE usage fails schema validation.

This PR adds `HPKE` to `algorithmFamiliesEnum` (alphabetically between `GOST` and `HC`).