### PR TITLE
fix(registry): correct ANSI INCITS 92-1981 reference URL

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -602,7 +602,7 @@
         },
         {
           "name": "ANSI INCITS 92-1981",
-          "url": "https://csrc.nist.gov/pubs/fips/46-3/final"
+          "url": "https://webstore.ansi.org/standards/incits/ansiincits921981r2003"
         }
       ],
       "variant": [


### PR DESCRIPTION
Fixes #806

The DES entry referenced ANSI INCITS 92-1981, but the URL incorrectly pointed to NIST FIPS 46-3. This PR updates standard.url to the official ANSI Webstore listing (paywalled). 