### PR TITLE
fix(tests): enable JS functional tests for CycloneDX 2.0

### DIFF
--- a/tools/src/test/js/package.json
+++ b/tools/src/test/js/package.json
@@ -18,6 +18,7 @@
     "test": "run-s test:\\*",
     "test:json-schema-lint": "node -- json-schema-lint-tests.js",
     "test:json-schema-functional": "run-s test:json-schema-functional:\\*",
+    "test:json-schema-functional:2.0": "node -- json-schema-functional-tests.js -v 2.0",
     "test:json-schema-functional:1.7": "node -- json-schema-functional-tests.js -v 1.7",
     "test:json-schema-functional:1.6": "node -- json-schema-functional-tests.js -v 1.6",
     "test:json-schema-functional:1.5": "node -- json-schema-functional-tests.js -v 1.5",

--- a/tools/src/test/resources/2.0/valid-cryptography-certificate-2.0.json
+++ b/tools/src/test/resources/2.0/valid-cryptography-certificate-2.0.json
@@ -62,7 +62,7 @@
         "algorithmProperties": {
           "primitive": "signature",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": [
             "none"
           ],
@@ -120,7 +120,7 @@
           "algorithmFamily": "RSAES-OAEP",
           "parameterSetIdentifier": "2048",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": [
             "none"
           ],

--- a/tools/src/test/resources/2.0/valid-cryptography-certificate-advanced-2.0.json
+++ b/tools/src/test/resources/2.0/valid-cryptography-certificate-advanced-2.0.json
@@ -183,7 +183,7 @@
         "algorithmProperties": {
           "primitive": "signature",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "padding": "pkcs1v15",
           "cryptoFunctions": [
             "sign",
@@ -203,7 +203,7 @@
           "primitive": "signature",
           "ellipticCurve": "secg/secp256r1",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": [
             "sign",
@@ -231,7 +231,7 @@
           "updateDate": "2024-01-10T15:45:30Z",
           "securedBy": {
             "mechanism": "HSM",
-            "algorithmRef": "aes-256-gcm-ref"
+            "algorithmRef": ["aes-256-gcm-ref"]
           },
           "fingerprint": {
             "alg": "SHA-256",
@@ -265,7 +265,7 @@
           "expirationDate": "2025-01-01T23:59:59Z",
           "securedBy": {
             "mechanism": "HSM",
-            "algorithmRef": "aes-256-gcm-ref"
+            "algorithmRef": ["aes-256-gcm-ref"]
           },
           "fingerprint": {
             "alg": "SHA-256",

--- a/tools/src/test/resources/2.0/valid-cryptography-full-2.0.json
+++ b/tools/src/test/resources/2.0/valid-cryptography-full-2.0.json
@@ -17,7 +17,7 @@
           "parameterSetIdentifier": "160",
           "ellipticCurve": "brainpool/brainpoolP160r1",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l4"],
           "cryptoFunctions": [
             "keygen",
@@ -40,7 +40,7 @@
           "algorithmFamily": "RSASSA-PKCS1",
           "parameterSetIdentifier": "2048",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "padding": "pkcs1v15",
           "cryptoFunctions": ["sign", "verify"],
@@ -61,7 +61,7 @@
           "parameterSetIdentifier": "256",
           "mode": "gcm",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["keygen", "encrypt", "decrypt", "tag"],
           "classicalSecurityLevel": 256,
@@ -81,7 +81,7 @@
           "algorithmFamily": "SHA-2",
           "parameterSetIdentifier": "256",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["digest"]
         },
@@ -99,7 +99,7 @@
           "algorithmFamily": "SHA-2",
           "parameterSetIdentifier": "384",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["digest"]
         },
@@ -118,7 +118,7 @@
           "parameterSetIdentifier": "128",
           "mode": "gcm",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["keygen", "encrypt", "decrypt", "tag"],
           "classicalSecurityLevel": 128,
@@ -137,7 +137,7 @@
           "primitive": "ae",
           "algorithmFamily": "ChaCha20",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": ["keygen", "encrypt", "decrypt", "tag"],
           "classicalSecurityLevel": 256,
@@ -156,7 +156,7 @@
           "primitive": "key-agree",
           "algorithmFamily": "FFDH",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["keygen", "keyderive"]
         },
@@ -174,7 +174,7 @@
           "algorithmFamily": "ECDSA",
           "ellipticCurve": "secg/secp256r1",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "cryptoFunctions": ["sign", "verify"]
         },
@@ -192,7 +192,7 @@
           "algorithmFamily": "RSAES-OAEP",
           "parameterSetIdentifier": "4096",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["fips140-3-l1"],
           "padding": "oaep",
           "cryptoFunctions": ["keygen", "encrypt", "decrypt"]
@@ -219,7 +219,7 @@
           "format": "PEM",
           "securedBy": {
             "mechanism": "HSM",
-            "algorithmRef": "algorithm-aes-256-gcm"
+            "algorithmRef": ["algorithm-aes-256-gcm"]
           },
           "fingerprint": {
             "alg": "SHA-256",

--- a/tools/src/test/resources/2.0/valid-cryptography-implementation-2.0.json
+++ b/tools/src/test/resources/2.0/valid-cryptography-implementation-2.0.json
@@ -24,7 +24,7 @@
           "parameterSetIdentifier": "128",
           "mode": "gcm",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": [
             "keygen",
@@ -48,7 +48,7 @@
           "primitive": "signature",
           "parameterSetIdentifier": "512",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": [
             "sign",
@@ -70,7 +70,7 @@
           "ellipticCurve": "secg/secp521r1",
           "primitive": "key-agree",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": [
             "keygen",
@@ -91,7 +91,7 @@
           "algorithmFamily": "ML-KEM",
           "primitive": "kem",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": [
             "keygen",
@@ -111,7 +111,7 @@
         "algorithmProperties": {
           "primitive": "combiner",
           "executionEnvironment": "software-plain-ram",
-          "implementationPlatform": "x86_64",
+          "implementationPlatform": ["x86_64"],
           "certificationLevel": ["none"],
           "cryptoFunctions": [
             "keygen",


### PR DESCRIPTION
### What
Fixes the JS functional test harness for CycloneDX 2.0:
- Resolve the correct 2.0 schema (`schema/2.0/cyclonedx-2.0-bundled.schema.json`) when running `-v 2.0`.
- Use the Ajv 2020-12 build for 2.0 schemas.
- Register referenced schemas under both http and https IDs to avoid ref resolution mismatches.
- Align 2.0 cryptography "valid-*" test vectors with the bundled schema by wrapping single values in one-element arrays:
  - `components[].cryptoProperties.algorithmProperties.implementationPlatform`
  - `components[].cryptoProperties.securedBy[].algorithmRef`

### Why
`node tools/src/test/js/json-schema-functional-tests.js -v 2.0` previously failed due to:
- outdated schema path assumptions (`schema/bom-2.0.schema.json`)
- missing draft 2020-12 meta-schema support in Ajv
- a small mismatch in 2.0 cryptography test vectors where the schema expects arrays

### Testing
- `cd tools/src/test/js && npm install && npm test`
- `node json-schema-functional-tests.js -v 2.0`

Closes #835
