### PR TITLE
fix(crypto-registry): normalize RFC/FIPS standard name formatting

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -418,7 +418,7 @@
         {
           "standard": [
             {
-              "name": "RFC 5297",
+              "name": "RFC5297",
               "url": "https://doi.org/10.17487/RFC5297"
             }
           ],
@@ -723,7 +723,7 @@
       "family": "ML-DSA",
       "standard": [
         {
-          "name": "FIPS 204",
+          "name": "FIPS204",
           "url": "https://doi.org/10.6028/NIST.FIPS.204"
         }
       ],
@@ -742,7 +742,7 @@
       "family": "SLH-DSA",
       "standard": [
         {
-          "name": "FIPS 205",
+          "name": "FIPS205",
           "url": "https://doi.org/10.6028/NIST.FIPS.205"
         }
       ],
@@ -811,7 +811,7 @@
       "family": "ML-KEM",
       "standard": [
         {
-          "name": "FIPS 203",
+          "name": "FIPS203",
           "url": "https://doi.org/10.6028/NIST.FIPS.203"
         }
       ],


### PR DESCRIPTION
This PR normalizes a few outlier `standard.name` strings in `schema/cryptography-defs.json` to match the existing naming convention:
- `RFC 5297` -> `RFC5297`
- `FIPS 203/204/205` -> `FIPS203/FIPS204/FIPS205`

URLs are unchanged; this is a string-formatting consistency fix only.

Fixes #846