### PR TITLE
fix(schema): correct typos in BOM 1.6/1.7 JSON Schema and XSD

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -536,7 +536,7 @@
       "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
       "type": "string",
       "minLength": 1,
-      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+      "$comment": "TODO (breaking change): add a format constraint that prevents the value from starting with 'urn:cdx:'"
     },
     "refLinkType": {
       "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
@@ -1161,7 +1161,7 @@
         "contentType": {
           "type": "string",
           "title": "Content-Type",
-          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plain text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
           "default": "text/plain",
           "examples": [
             "text/plain",

--- a/schema/bom-1.6.xsd
+++ b/schema/bom-1.6.xsd
@@ -973,7 +973,7 @@ limitations under the License.
                         <xs:documentation>
                             Specifies the format and nature of the data being attached, helping systems correctly
                             interpret and process the content. Common content type examples include `application/json`
-                            for JSON data and `text/plain` for plan text documents.
+                            for JSON data and `text/plain` for plain text documents.
                             RFC 2045 section 5.1 outlines the structure and use of content types. For a comprehensive
                             list of registered content types, refer to the IANA media types registry at
                             https://www.iana.org/assignments/media-types/media-types.xhtml.

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -555,7 +555,7 @@
       "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
       "type": "string",
       "minLength": 1,
-      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+      "$comment": "TODO (breaking change): add a format constraint that prevents the value from starting with 'urn:cdx:'"
     },
     "refLinkType": {
       "title": "BOM Reference",
@@ -1248,7 +1248,7 @@
         "contentType": {
           "type": "string",
           "title": "Content-Type",
-          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plain text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
           "default": "text/plain",
           "examples": [
             "text/plain",

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -1204,7 +1204,7 @@ limitations under the License.
                         <xs:documentation>
                             Specifies the format and nature of the data being attached, helping systems correctly
                             interpret and process the content. Common content type examples include `application/json`
-                            for JSON data and `text/plain` for plan text documents.
+                            for JSON data and `text/plain` for plain text documents.
                             RFC 2045 section 5.1 outlines the structure and use of content types. For a comprehensive
                             list of registered content types, refer to the IANA media types registry at
                             https://www.iana.org/assignments/media-types/media-types.xhtml.


### PR DESCRIPTION
Fixes two minor typos in released BOM 1.6/1.7 artifacts:

- Replace "plan text" with "plain text" in content-type descriptions:
  - `schema/bom-1.6.schema.json`
  - `schema/bom-1.7.schema.json`
  - `schema/bom-1.6.xsd`
  - `schema/bom-1.7.xsd`
- Fix typo in `refType` comment ("staring" -> "starting"):
  - `schema/bom-1.6.schema.json`
  - `schema/bom-1.7.schema.json`

No validation semantics changed; copy/comment updates only.

Fixes #849
