### PR TITLE
docs: remove buf comments

### DIFF
--- a/docgen/proto/gen.sh
+++ b/docgen/proto/gen.sh
@@ -67,6 +67,9 @@ generate () {
   sed -i -e "s/\${title}/$title/g" "$OUT_DIR/$OUT_FILE"
   sed -i -e "s/\${version}/$version/g" "$OUT_DIR/$OUT_FILE"
 
+  sed -i -E -e "s#(<p>)buf:.+</p>##g" "$OUT_DIR/$OUT_FILE"
+  sed -i -E -e "s#^buf:[^<\n]+##g" "$OUT_DIR/$OUT_FILE"
+
   inject_header "$OUT_DIR/$OUT_FILE" "$version" "proto"
 }
 


### PR DESCRIPTION
in the protobuf schema we use annotations for some linters and other tools.
these annotations start with `buf:`

these annotations are not meant for humans, so we dont need to render them in the docs.

this PR removes these things from the docs. 