### PR TITLE
CBOM: add custom fingerprints

### DIFF
--- a/schema/2.0/model/cyclonedx-common-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-common-2.0.schema.json
@@ -54,10 +54,14 @@
       "additionalProperties": false,
       "properties": {
         "alg": {
-          "$ref": "#/$defs/hashAlgorithm"
+          "$ref": "#/$defs/hashAlgorithm",
+          "title": "Hash Algorithm",
+          "description": "The standard, well-known algorithm used to compute the hash."
         },
         "content": {
-          "$ref": "#/$defs/hashValue"
+          "$ref": "#/$defs/hashValue",
+          "title": "Hash Value",
+          "description": "The value of the hash computed using the standard, well-known algorithm."
         }
       }
     },

--- a/schema/2.0/model/cyclonedx-cryptography-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-cryptography-2.0.schema.json
@@ -416,7 +416,7 @@
               ]
             },
             "fingerprint": {
-              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hash",
+              "$ref": "#/$defs/fingerprint",
               "title": "Certificate Fingerprint",
               "description": "The fingerprint is a cryptographic hash of the certificate excluding it's signature."
             },
@@ -718,9 +718,7 @@
               "description": "The mechanism by which the cryptographic asset is secured by."
             },
             "fingerprint": {
-              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hash",
-              "title": "Fingerprint",
-              "description": "The fingerprint is a cryptographic hash of the asset."
+              "$ref": "#/$defs/fingerprint"
             },
             "relatedCryptographicAssets": {
               "$ref": "#/$defs/relatedCryptographicAssets"
@@ -1118,6 +1116,45 @@
           "description": "The bom-ref to cryptographic asset."
         }
       }
+    },
+    "fingerprint": {
+      "type": "object",
+      "title": "Fingerprint",
+      "description": "The fingerprint is a cryptographic hash of the asset.",
+      "oneOf": [
+        {
+          "title": "Standard Hash",
+          "description": "A fingerprint computed using a standard, well-known hash algorithm.",
+          "required": ["alg", "content"],
+          "additionalProperties": false,
+          "properties": {
+            "alg": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hashAlgorithm"
+            },
+            "content": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hashValue"
+            }
+          }
+        },
+        {
+          "title": "Custom Fingerprint",
+          "description": "A fingerprint computed with a custom or non-standard algorithm not covered by the standard hash algorithms.",
+          "required": ["customAlg", "customContent"],
+          "additionalProperties": false,
+          "properties": {
+            "customAlg": {
+              "type": "string",
+              "title": "Custom Fingerprint Algorithm",
+              "description": "The name of the custom algorithm used to compute the fingerprint."
+            },
+            "customContent": {
+              "type": "string",
+              "title": "Custom Fingerprint Content",
+              "description": "The value of the fingerprint computed using the custom algorithm."
+            }
+          }
+        }
+      ]
     },
     "securedBy": {
       "type": "object",


### PR DESCRIPTION
Extend the `fingerprint` definition in `cyclonedx-cryptography-2.0.schema.json` to support custom fingerprint algorithms alongside standard hash algorithms.

### Changes

- Replace the flat `$ref: hash` on `certificateProperties.fingerprint` and `relatedCryptoMaterialProperties.fingerprint` with a single central `$defs/fingerprint` definition
- `$defs/fingerprint` uses `oneOf` with two branches:
  - **Standard Hash** — `alg` + `content` (refs to existing `hashAlgorithm` / `hashValue`); fully backward compatible
  - **Custom Fingerprint** — `customAlg` + `customContent` for non-standard algorithms

### Backward Compatibility

Existing documents with `{"alg": "SHA-256", "content": "..."}` satisfy the Standard Hash branch unchanged.