### PR TITLE
fix: correct GOST 28147 algorithm names

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -970,7 +970,7 @@
               "url": "https://doi.org/10.17487/RFC4357"
             }
           ],
-          "pattern": "GOST38147[-{mode}][-{padding}]",
+          "pattern": "GOST28147[-{mode}][-{padding}]",
           "primitive": "block-cipher"
         },
         {
@@ -980,7 +980,7 @@
               "url": "https://doi.org/10.17487/RFC4357"
             }
           ],
-          "pattern": "GOST38147_MAC",
+          "pattern": "GOST28147_MAC",
           "primitive": "mac"
         }
       ]


### PR DESCRIPTION
## Summary

Corrects misspelled GOST 28147 algorithm patterns in `schema/cryptography-defs.json`.

## Changes

Updates:

- `GOST38147[-{mode}][-{padding}]` to `GOST28147[-{mode}][-{padding}]`

- `GOST38147_MAC` to `GOST28147_MAC`

## Rationale

RFC 4357 defines the block cipher as GOST 28147-89. The previous patterns used `38147`, which appears to be a typo.

## Validation

- Validated `schema/cryptography-defs.json`

- Verified no `GOST38147` references remain under `schema`

Fixes #920