### PR TITLE
fix: correct BLS12 algorithm pattern

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -1280,7 +1280,7 @@
       ],
       "variant": [
         {
-          "pattern": "BLS(13-381|13-377|BN254)",
+          "pattern": "BLS(12-381|12-377|BN254)",
           "primitive": "signature"
         },
         {


### PR DESCRIPTION
## Summary

Corrects the BLS pattern in `schema/cryptography-defs.json`.

## Changes

- `BLS(13-381|13-377|BN254)` to `BLS(12-381|12-377|BN254)`

## Rationale

The repository's elliptic curve catalog uses `BLS12-381` and `BLS12-377`, and RFC 9380 references `BLS12-381`. The previous `BLS13-*` values appear to be typos.

## Validation

- Validated `schema/cryptography-defs.json`
- Verified no `BLS(13-381|13-377|BN254)` reference remains

Fixes #922