### PR TITLE
fix(xml): allow protocol cryptographic relationships

### DIFF
--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -8295,8 +8295,48 @@ limitations under the License.
                         </xs:element>
                         <xs:element name="cryptoRef" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
                             <xs:annotation>
-                                <xs:documentation>A protocol-related cryptographic assets</xs:documentation>
+                                <xs:documentation>
+                                    DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./relatedCryptographicAssets` instead.
+                                    A protocol-related cryptographic asset.
+                                </xs:documentation>
                             </xs:annotation>
+                        </xs:element>
+                        <xs:element name="relatedCryptographicAssets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cryptographic assets related to this component.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="relatedCryptographicAsset" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A cryptographic asset related to this component.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Specifies the mechanism by which the cryptographic asset is secured by.
+                                                            Examples: "publicKey", "privateKey", "algorithm"
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="ref" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
                         </xs:element>
                     </xs:sequence>
                 </xs:complexType>

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.json
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.json
@@ -239,7 +239,13 @@
                 "algorithm": "ecdsa_secp256r1_sha256"
               }
             ]
-          }
+          },
+          "relatedCryptographicAssets": [
+            {
+              "type": "publicKey",
+              "ref": "asset-4"
+            }
+          ]
         },
         "oid": "oid:1.3.6.1.5.5.7.3.1"
       }

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.textproto
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.textproto
@@ -231,6 +231,12 @@ components: {
           algorithm: "ecdsa_secp256r1_sha256"
         }
       }
+      relatedCryptographicAssets: {
+        assets: {
+          type: "publicKey"
+          ref: "asset-4"
+        }
+      }
     }
     oid: "oid:1.3.6.1.5.5.7.3.1"
   }

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.xml
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.xml
@@ -220,6 +220,12 @@
                             <algorithm>ecdsa_secp256r1_sha256</algorithm>
                         </auth>
                     </ikev2TransformTypes>
+                    <relatedCryptographicAssets>
+                        <relatedCryptographicAsset>
+                            <type>publicKey</type>
+                            <ref>asset-4</ref>
+                        </relatedCryptographicAsset>
+                    </relatedCryptographicAssets>
                 </protocolProperties>
                 <oid>oid:1.3.6.1.5.5.7.3.1</oid>
             </cryptoProperties>


### PR DESCRIPTION
The CycloneDX 1.7 JSON Schema is the reference implementation and defines relatedCryptographicAssets on protocol properties. Protobuf exposes the same relationship, but the XML schema omitted it, leaving the three representations inconsistent and preventing valid protocol relationships from passing XSD validation.

Add the preferred relationship collection after the deprecated cryptoRef elements, matching the existing certificate and related-material XML structures. Clarify that cryptoRef is deprecated, and exercise the same protocol-to-public-key relationship in the XML, JSON, and Protobuf full cryptography examples.

- Fixes https://github.com/CycloneDX/specification/issues/1018
