### PR TITLE
fix: allow protocol related cryptographic assets in XML

### DIFF
--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -8298,6 +8298,43 @@ limitations under the License.
                                 <xs:documentation>A protocol-related cryptographic assets</xs:documentation>
                             </xs:annotation>
                         </xs:element>
+                        <xs:element name="relatedCryptographicAssets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cryptographic assets related to this component.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="relatedCryptographicAsset" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A cryptographic asset related to this component.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Specifies the mechanism by which the cryptographic asset is secured by.
+                                                            Examples: "publicKey", "privateKey", "algorithm"
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="ref" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.json
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.json
@@ -239,7 +239,17 @@
                 "algorithm": "ecdsa_secp256r1_sha256"
               }
             ]
-          }
+          },
+          "relatedCryptographicAssets": [
+            {
+              "type": "algorithm",
+              "ref": "asset-1"
+            },
+            {
+              "type": "certificate",
+              "ref": "asset-2"
+            }
+          ]
         },
         "oid": "oid:1.3.6.1.5.5.7.3.1"
       }

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.textproto
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.textproto
@@ -231,6 +231,16 @@ components: {
           algorithm: "ecdsa_secp256r1_sha256"
         }
       }
+      relatedCryptographicAssets: {
+        assets: {
+          type: "algorithm"
+          ref: "asset-1"
+        }
+        assets: {
+          type: "certificate"
+          ref: "asset-2"
+        }
+      }
     }
     oid: "oid:1.3.6.1.5.5.7.3.1"
   }

--- a/tools/src/test/resources/1.7/valid-cryptography-full-1.7.xml
+++ b/tools/src/test/resources/1.7/valid-cryptography-full-1.7.xml
@@ -220,6 +220,16 @@
                             <algorithm>ecdsa_secp256r1_sha256</algorithm>
                         </auth>
                     </ikev2TransformTypes>
+                    <relatedCryptographicAssets>
+                        <relatedCryptographicAsset>
+                            <type>algorithm</type>
+                            <ref>asset-1</ref>
+                        </relatedCryptographicAsset>
+                        <relatedCryptographicAsset>
+                            <type>certificate</type>
+                            <ref>asset-2</ref>
+                        </relatedCryptographicAsset>
+                    </relatedCryptographicAssets>
                 </protocolProperties>
                 <oid>oid:1.3.6.1.5.5.7.3.1</oid>
             </cryptoProperties>


### PR DESCRIPTION
## Summary

- allow XML `protocolProperties` to use the preferred `relatedCryptographicAssets` representation already available in JSON Schema and Protobuf
- extend the full cryptography fixtures in XML, JSON, and textproto so the field stays covered across formats

- Fixes #1018.

## Verification

- reproduced the regression before the XSD change: the Java XML suite reported only `1.7/valid-cryptography-full-1.7.xml` failing
- `mvn clean test` (769 tests)
- `npm test` on Linux with Node 24
- Buf 1.58.0 lint, remote and adjacent-version breaking checks, plus all 193 valid textproto fixtures
- PHP JSON/XML schema scripts for every supported version
- `docgen/xml/gen.sh` for XML documentation versions 1.0 through 1.7; the generated 1.7 reference includes the new element

## AI assistance

OpenAI Codex assisted with repository research, implementation, and test execution. I reviewed the change and its generated output, reproduced the failure before the fix, ran the validations above, and take responsibility for the contribution.
