### PR TITLE
fix: extend GOST registry with 2012/2015 algorithms and curve OIDs

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -982,6 +982,56 @@
           ],
           "pattern": "GOST28147_MAC",
           "primitive": "mac"
+        },
+        {
+          "standard": [
+            {
+              "name": "RFC7091",
+              "url": "https://doi.org/10.17487/RFC7091"
+            }
+          ],
+          "pattern": "GOSTR3410-2012-(256|512)",
+          "primitive": "signature"
+        },
+        {
+          "standard": [
+            {
+              "name": "RFC6986",
+              "url": "https://doi.org/10.17487/RFC6986"
+            }
+          ],
+          "pattern": "GOSTR3411-2012-(256|512)",
+          "primitive": "hash"
+        },
+        {
+          "standard": [
+            {
+              "name": "RFC7836",
+              "url": "https://doi.org/10.17487/RFC7836"
+            }
+          ],
+          "pattern": "HMAC-GOSTR3411-2012-(256|512)",
+          "primitive": "mac"
+        },
+        {
+          "standard": [
+            {
+              "name": "RFC8891",
+              "url": "https://doi.org/10.17487/RFC8891"
+            }
+          ],
+          "pattern": "Magma[-{mode}][-{padding}]",
+          "primitive": "block-cipher"
+        },
+        {
+          "standard": [
+            {
+              "name": "RFC7801",
+              "url": "https://doi.org/10.17487/RFC7801"
+            }
+          ],
+          "pattern": "Kuznyechik[-{mode}][-{padding}]",
+          "primitive": "block-cipher"
         }
       ]
     },
@@ -2195,43 +2245,43 @@
         {
           "name": "id-GostR3410-2001-CryptoPro-A-ParamSet",
           "description": "RFC4357",
-          "oid": null,
+          "oid": "1.2.643.2.2.35.1",
           "form": "Weierstrass"
         },
         {
           "name": "id-GostR3410-2001-CryptoPro-B-ParamSet",
           "description": "RFC4357",
-          "oid": null,
+          "oid": "1.2.643.2.2.35.2",
           "form": "Weierstrass"
         },
         {
           "name": "id-GostR3410-2001-CryptoPro-C-ParamSet",
           "description": "RFC4357",
-          "oid": null,
+          "oid": "1.2.643.2.2.35.3",
           "form": "Weierstrass"
         },
         {
           "name": "id-tc26-gost-3410-12-512-paramSetA",
           "description": "RFC7836",
-          "oid": null,
+          "oid": "1.2.643.7.1.2.1.2.1",
           "form": "Weierstrass"
         },
         {
           "name": "id-tc26-gost-3410-12-512-paramSetB",
           "description": "RFC7836",
-          "oid": null,
+          "oid": "1.2.643.7.1.2.1.2.2",
           "form": "Weierstrass"
         },
         {
           "name": "id-tc26-gost-3410-2012-256-paramSetA",
-          "description": "RFC5832",
-          "oid": null,
+          "description": "RFC7836",
+          "oid": "1.2.643.7.1.2.1.1.1",
           "form": "TwistedEdwards"
         },
         {
           "name": "id-tc26-gost-3410-2012-512-paramSetC",
-          "description": "RFC5832",
-          "oid": null,
+          "description": "RFC7836",
+          "oid": "1.2.643.7.1.2.1.2.3",
           "form": "TwistedEdwards"
         }
       ]


### PR DESCRIPTION
## Summary
- Added GOST R 34.10-2012 signature pattern `GOSTR3410-2012-(256|512)` (RFC 7091)
- Added GOST R 34.11-2012 hash pattern `GOSTR3411-2012-(256|512)` (RFC 6986)
- Added HMAC pattern `HMAC-GOSTR3411-2012-(256|512)` (RFC 7836)
- Added Magma and Kuznyechik block-cipher patterns (RFC 8891, RFC 7801)
- Corrected TC26 Twisted Edwards curve citations from RFC 5832 to RFC 7836
- Populated CryptoPro-A/B/C and TC26 curve OIDs from RFC 4357 / RFC 7836

Closes #1025



