### PR TITLE
2.0 dev fix bundler result schema name

### DIFF
--- a/tools/src/main/js/bundler/bundle-schemas.js
+++ b/tools/src/main/js/bundler/bundle-schemas.js
@@ -342,7 +342,9 @@ async function bundleSchemas(modelsDirectory, rootSchemaPath, options = {}) {
             }
         }
 
+
         // Write bundled (pretty) version
+        // TODO: set schema name
         console.log('\nWriting bundled schema...');
         const prettyJson = JSON.stringify(finalSchema, null, 2);
         await fs.writeFile(bundledPath, prettyJson);
@@ -351,6 +353,7 @@ async function bundleSchemas(modelsDirectory, rootSchemaPath, options = {}) {
         console.log(`✓ Bundled schema: ${bundledFilename} (${bundledSizeKB} KB)`);
 
         // Write minified version
+        // TODO: set schema name
         console.log('Writing minified schema...');
         const minifiedSchema = removeComments(finalSchema, true);
         const minifiedJson = JSON.stringify(minifiedSchema);

--- a/tools/src/main/js/bundler/bundle-schemas.js
+++ b/tools/src/main/js/bundler/bundle-schemas.js
@@ -344,19 +344,23 @@ async function bundleSchemas(modelsDirectory, rootSchemaPath, options = {}) {
 
 
         // Write bundled (pretty) version
-        // TODO: set schema name
         console.log('\nWriting bundled schema...');
-        const prettyJson = JSON.stringify(finalSchema, null, 2);
+        const prettyJson = JSON.stringify({
+            ...finalSchema,
+            "$id": new URL(bundledFilename, finalSchema['$id']).toString()
+        }, null, 2);
         await fs.writeFile(bundledPath, prettyJson);
         const bundledStats = await fs.stat(bundledPath);
         const bundledSizeKB = (bundledStats.size / 1024).toFixed(2);
         console.log(`✓ Bundled schema: ${bundledFilename} (${bundledSizeKB} KB)`);
 
         // Write minified version
-        // TODO: set schema name
         console.log('Writing minified schema...');
         const minifiedSchema = removeComments(finalSchema, true);
-        const minifiedJson = JSON.stringify(minifiedSchema);
+        const minifiedJson = JSON.stringify({
+            ...minifiedSchema,
+            "$id": new URL(minifiedFilename, finalSchema['$id']).toString()
+        });
 
         // Verify it's a single line
         const lineCount = minifiedJson.split('\n').length;


### PR DESCRIPTION
the bundler produced files 
- cyclonedx-2.0-bundled.min.schema.json
- cyclonedx-2.0-bundled.schema.json

but it did not set the proper `$id` for these output files.
it kept them untouched. leading to possible errors downstream.

background:
the original schema `cyclonedx-api-2.0.schema.json` defined an id.
that one was reused in those bundled schemas which actually were not congruent, though they might have validated the same structure: 
- the bundled versions had those `$defs/cyclonedx-...-2.0/` that the `cyclonedx-api-2.0.schema.json` did not have.
- therefore when using the `cyclonedx-api-2.0.schema.json` for the original id, you could not access those `$defs` that were in a bundle. 
- since all schema files claimed to have the same id, they were functionally different for downstream usage.
- they were not interchangeable.

since they were not interchangeable, the id must be different.


motivation:
i could write an own validator based on cyclonedx, where i would reuse the $devs provided by the schema.
if i switched from the minified/bundled version to the original one, it would break, even though both claim to be interchangeable since they have the same schema. 




