### PR TITLE
fix: LMOTS pattern, add HSS variant (LMS family)

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -810,7 +810,11 @@
           "primitive": "signature"
         },
         {
-          "pattern": "LMOTS[_{hashfun}][_N{bytespernode}][_H{treeheight}]",
+          "pattern": "LMOTS[_{hashAlgorithm}][_N{bytesPerNode}][_W{winternitzParameter}]",
+          "primitive": "signature"
+        },
+        {
+          "pattern": "HSS[_L{levels}]",
           "primitive": "signature"
         }
       ]


### PR DESCRIPTION
Hi, 
LMOTS had a treeHeight parameter it shouldn't — LM-OTS doesn't use a Merkle tree, so there's no height involved. Swapped it for the Winternitz parameter w, which is what actually distinguishes the RFC's parameter sets (LMOTS_SHA256_N32_W1/W2/W4/W8).

Also added HSS, which was missing entirely. It's just the multi-level LMS construction, parameterized by number of levels (L), so the pattern is intentionally minimal — no hash/M/H, since those come from whichever LMS parameter set each level uses.

LMS itself was already correct.

```
"LMOTS[_{hashAlgorithm}][_N{bytesPerNode}][_W{winternitzParameter}]"
"HSS[_L{levels}]"
```
One question — LMOTS still reuses {bytesPerNode} for its N parameter, but RFC 8554 calls this n — the LM-OTS hash output length, not a node value (LM-OTS has no tree nodes). Should this be renamed to something like {hashOutputLength} on LMOTS, keeping {bytesPerNode} only on LMS where it's accurate? Didn't want to bundle a naming change into this fix, so leaving it open — happy to push a follow-up if there's agreement either way.

Closes #1028.