### PR TITLE
ci: linter as matrix

### DIFF
--- a/.github/workflows/lint_2.x_schemas.yml
+++ b/.github/workflows/lint_2.x_schemas.yml
@@ -14,7 +14,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  discover-schemas:
+  discover-schema:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
@@ -42,15 +42,48 @@ jobs:
           fi
           printf 'versions=' >> "$GITHUB_OUTPUT"
           printf '%s\n' "${dirs[@]}" | jq -R . | jq -c -s . >> "$GITHUB_OUTPUT"
+  discover-linter:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.discover.outputs.tests }}
+    steps:
+      - name: Checkout repository
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.x'
+          package-manager-cache: false
+      - name: Install linter
+        working-directory: tools/src/main/js/linter
+        run: npm install
+      - name: Discover linter tests
+        id: discover
+        run: |
+          printf 'tests=' >> "$GITHUB_OUTPUT"
+          node tools/src/main/js/linter/cli.js -l -f json >> "$GITHUB_OUTPUT"
   lint-schemas:
-    needs: discover-schemas
-    timeout-minutes: 30
+    needs:
+      - discover-schema
+      - discover-linter
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJSON(needs.discover-schemas.outputs.versions) }}
-    name: lint-schemas (${{ matrix.version }})
+        schema_version: ${{ fromJSON(needs.discover-schema.outputs.versions) }}
+        linter_test: ${{ fromJSON(needs.discover-linter.outputs.tests) }}
+      # you could exclude some combinations via matrix.exclude
+      # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrixexclude
+        exclude:
+          - schema_version: '2.0'
+            linter_test: 'no-uppercase-rfc'
+    name: ${{ matrix.schema_version }} ${{ matrix.linter_test }}
     steps:
       - name: Checkout repository
         # see https://github.com/actions/checkout
@@ -72,7 +105,8 @@ jobs:
         run: npm install
       - name: Lint schemas
         env:
-          SCHEMA_VERSION: ${{ matrix.version }}
+          SCHEMA_VERSION: ${{ matrix.schema_version }}
+          LINTER_TEST: ${{ matrix.linter_test }}
         run: |
           mapfile -d '' -t schemas < <(
             find "schema/${SCHEMA_VERSION}" \
@@ -86,6 +120,7 @@ jobs:
             exit 1
           fi
           node tools/src/main/js/linter/cli.js \
+            --include "$LINTER_TEST" \
             --format json \
             "${schemas[@]}" \
             > "tools/src/main/js/linter/CI_report.json"
@@ -97,7 +132,7 @@ jobs:
         # https://github.com/actions/upload-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: report-${{ matrix.version }}.json
+          name: report-${{ matrix.schema_version }}-${{ matrix.linter_test }}.json
           path: tools/src/main/js/linter/CI_report.json
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/lint_2.x_schemas.yml
+++ b/.github/workflows/lint_2.x_schemas.yml
@@ -78,11 +78,11 @@ jobs:
       matrix:
         schema_version: ${{ fromJSON(needs.discover-schema.outputs.versions) }}
         linter_test: ${{ fromJSON(needs.discover-linter.outputs.tests) }}
-      # you could exclude some combinations via matrix.exclude
-      # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrixexclude
-        exclude:
-          - schema_version: '2.0'
-            linter_test: 'no-uppercase-rfc'
+        # you could exclude some combinations via matrix.exclude
+        # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrixexclude
+        # exclude:
+        #  - schema_version: '2.0'
+        #    linter_test: 'no-uppercase-rfc'
     name: ${{ matrix.schema_version }} ${{ matrix.linter_test }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint_2.x_schemas.yml
+++ b/.github/workflows/lint_2.x_schemas.yml
@@ -1,4 +1,4 @@
-name: Lint CycloneDX 2.x JSON Schemas
+name: CT CDX-2.x Lint
 
 on:
   push:

--- a/.github/workflows/lint_2.x_schemas.yml
+++ b/.github/workflows/lint_2.x_schemas.yml
@@ -13,6 +13,9 @@ concurrency:
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
 
+env:
+  NODE_VERSION: '24.x'
+
 jobs:
   discover-schema:
     timeout-minutes: 5
@@ -57,7 +60,7 @@ jobs:
         # see https://github.com/actions/setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.x'
+          node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
       - name: Install linter
         working-directory: tools/src/main/js/linter
@@ -98,7 +101,7 @@ jobs:
         # see https://github.com/actions/setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.x'
+          node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
       - name: Install linter
         working-directory: tools/src/main/js/linter
@@ -136,3 +139,9 @@ jobs:
           path: tools/src/main/js/linter/CI_report.json
           if-no-files-found: error
           retention-days: 7
+  # summary:
+    # TODO: write a summary job that collects all artifacts,
+    #       and summarizes the result for each detected schema version
+    #       it might evenre-package all the artifacts to a `report-${{ matrix.schema_version }}_collected`
+    #       or something ... them we would no longer need to keep the other artifacts for long (maybea day)
+    # but this is to come in a different task

--- a/tools/src/main/js/linter/cli.js
+++ b/tools/src/main/js/linter/cli.js
@@ -2,11 +2,11 @@
 
 /**
  * CycloneDX Schema Linter - Command Line Interface
- * 
+ *
  * Usage:
  *   cdx-lint [options] <files...>
  *   cdx-lint --help
- * 
+ *
  * @license Apache-2.0
  */
 
@@ -41,7 +41,7 @@ function parseArgs(args) {
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    
+
     if (arg === '--help' || arg === '-h') {
       options.showHelp = true;
     } else if (arg === '--version' || arg === '-v') {
@@ -67,7 +67,7 @@ function parseArgs(args) {
       console.error(`Unknown option: ${arg}`);
       process.exit(1);
     }
-    
+
     i++;
   }
 
@@ -137,18 +137,26 @@ function showVersion() {
 
 /**
  * Display list of available checks
+ * @param {string} [format=stylish]
  */
-function showChecks() {
-  console.log('\nAvailable Checks:\n');
-  
+function showChecks(format) {
   const checks = getRegisteredChecks();
-  const maxIdLength = Math.max(...Array.from(checks.keys()).map(k => k.length));
-  
-  for (const [id, check] of checks) {
-    const severity = check.defaultSeverity.toUpperCase().padEnd(7);
-    const paddedId = id.padEnd(maxIdLength + 2);
-    console.log(`  ${paddedId} [${severity}]  ${check.name}`);
-    console.log(`  ${' '.repeat(maxIdLength + 2)}            ${check.description}\n`);
+  switch (format) {
+      case 'json':
+          console.log(JSON.stringify(Array.from(checks.keys())))
+          break
+      case 'compact': // fall through - unless implemented
+      case 'stylish': // fall through - is default
+      default:
+          console.log('\nAvailable Checks:\n');
+          const maxIdLength = Math.max(...Array.from(checks.keys()).map(k => k.length));
+          for (const [id, check] of checks) {
+              const severity = check.defaultSeverity.toUpperCase().padEnd(7);
+              const paddedId = id.padEnd(maxIdLength + 2);
+              console.log(`  ${paddedId} [${severity}]  ${check.name}`);
+              console.log(`  ${' '.repeat(maxIdLength + 2)}            ${check.description}\n`);
+          }
+          break
   }
 }
 
@@ -163,7 +171,7 @@ function loadConfig(configPath) {
       '.cdxlintrc',
       'cdxlint.config.json'
     ];
-    
+
     for (const path of standardPaths) {
       if (existsSync(path)) {
         configPath = path;
@@ -171,7 +179,7 @@ function loadConfig(configPath) {
       }
     }
   }
-  
+
   if (configPath && existsSync(configPath)) {
     try {
       return JSON.parse(readFileSync(configPath, 'utf-8'));
@@ -180,7 +188,7 @@ function loadConfig(configPath) {
       process.exit(1);
     }
   }
-  
+
   return {};
 }
 
@@ -189,17 +197,17 @@ function loadConfig(configPath) {
  */
 function expandFilePaths(paths) {
   const files = [];
-  
+
   for (const path of paths) {
     const resolved = resolve(path);
-    
+
     if (!existsSync(resolved)) {
       console.error(`File not found: ${path}`);
       continue;
     }
-    
+
     const stat = statSync(resolved);
-    
+
     if (stat.isDirectory()) {
       // Recursively find JSON files
       const dirFiles = findJsonFiles(resolved);
@@ -208,7 +216,7 @@ function expandFilePaths(paths) {
       files.push(resolved);
     }
   }
-  
+
   return files;
 }
 
@@ -217,19 +225,19 @@ function expandFilePaths(paths) {
  */
 function findJsonFiles(dir) {
   const files = [];
-  
+
   const entries = readdirSync(dir, { withFileTypes: true });
-  
+
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
-    
+
     if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
       files.push(...findJsonFiles(fullPath));
     } else if (entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.schema.json'))) {
       files.push(fullPath);
     }
   }
-  
+
   return files;
 }
 
@@ -240,35 +248,35 @@ function formatStylish(results, options) {
   let output = '';
   let totalErrors = 0;
   let totalWarnings = 0;
-  
+
   // Track issues by check ID
   const checkStats = new Map();
-  
+
   for (const result of results) {
-    const issues = options.quiet 
+    const issues = options.quiet
       ? result.getIssuesBySeverity(Severity.ERROR)
       : result.issues;
-    
+
     if (issues.length === 0) continue;
-    
+
     output += `\n\x1b[4m${result.filePath}\x1b[0m\n`;
-    
+
     for (const issue of issues) {
-      const severityColour = issue.severity === Severity.ERROR 
+      const severityColour = issue.severity === Severity.ERROR
         ? '\x1b[31m' // red
-        : issue.severity === Severity.WARNING 
+        : issue.severity === Severity.WARNING
           ? '\x1b[33m' // yellow
           : '\x1b[36m'; // cyan
-      
+
       output += `  ${severityColour}${issue.severity}\x1b[0m  ${issue.path}\n`;
       output += `         ${issue.message} \x1b[90m(${issue.checkId})\x1b[0m\n`;
-      
+
       // Track stats by check ID
       if (!checkStats.has(issue.checkId)) {
         checkStats.set(issue.checkId, { errors: 0, warnings: 0, info: 0 });
       }
       const stats = checkStats.get(issue.checkId);
-      
+
       if (issue.severity === Severity.ERROR) {
         totalErrors++;
         stats.errors++;
@@ -280,15 +288,15 @@ function formatStylish(results, options) {
       }
     }
   }
-  
+
   if (totalErrors > 0 || totalWarnings > 0) {
     output += `\n\x1b[31m✖ ${totalErrors + totalWarnings} problems\x1b[0m`;
     output += ` (${totalErrors} errors, ${totalWarnings} warnings)\n`;
-    
+
     // Add summary table by check
     if (checkStats.size > 0) {
       output += '\n\x1b[1mIssues by check:\x1b[0m\n';
-      
+
       // Sort by total issues (descending)
       const sortedChecks = Array.from(checkStats.entries())
         .sort((a, b) => {
@@ -296,13 +304,13 @@ function formatStylish(results, options) {
           const totalB = b[1].errors + b[1].warnings + b[1].info;
           return totalB - totalA;
         });
-      
+
       // Find longest check name for alignment
       const maxNameLength = Math.max(...sortedChecks.map(([name]) => name.length));
-      
+
       for (const [checkId, stats] of sortedChecks) {
         const paddedName = checkId.padEnd(maxNameLength);
-        
+
         let statsStr = '';
         if (stats.errors > 0) {
           statsStr += `\x1b[31m${stats.errors} error${stats.errors !== 1 ? 's' : ''}\x1b[0m`;
@@ -315,14 +323,14 @@ function formatStylish(results, options) {
           if (statsStr) statsStr += ', ';
           statsStr += `\x1b[36m${stats.info} info\x1b[0m`;
         }
-        
+
         output += `  ${paddedName}  ${statsStr}\n`;
       }
     }
   } else {
     output += '\n\x1b[32m✔ No issues found\x1b[0m\n';
   }
-  
+
   return output;
 }
 
@@ -333,7 +341,7 @@ function formatJson(results, options) {
   const output = {
     results: results.map(r => ({
       filePath: r.filePath,
-      issues: options.quiet 
+      issues: options.quiet
         ? r.getIssuesBySeverity(Severity.ERROR).map(i => i.toJSON())
         : r.issues.map(i => i.toJSON()),
       summary: r.getSummary()
@@ -345,7 +353,7 @@ function formatJson(results, options) {
       totalWarnings: results.reduce((sum, r) => sum + r.getIssuesBySeverity(Severity.WARNING).length, 0)
     }
   };
-  
+
   return JSON.stringify(output, null, 2);
 }
 
@@ -354,17 +362,17 @@ function formatJson(results, options) {
  */
 function formatCompact(results, options) {
   let output = '';
-  
+
   for (const result of results) {
-    const issues = options.quiet 
+    const issues = options.quiet
       ? result.getIssuesBySeverity(Severity.ERROR)
       : result.issues;
-    
+
     for (const issue of issues) {
       output += `${result.filePath}: ${issue.path}: ${issue.severity}: ${issue.message} [${issue.checkId}]\n`;
     }
   }
-  
+
   return output;
 }
 
@@ -374,34 +382,34 @@ function formatCompact(results, options) {
 async function main() {
   const args = process.argv.slice(2);
   const options = parseArgs(args);
-  
+
   // Load all checks
   await loadAllChecks();
-  
+
   if (options.showHelp) {
     showHelp();
     process.exit(0);
   }
-  
+
   if (options.showVersion) {
     showVersion();
     process.exit(0);
   }
-  
+
   if (options.showChecks) {
-    showChecks();
+    showChecks(options.format);
     process.exit(0);
   }
-  
+
   if (options.files.length === 0) {
     console.error('Error: No input files specified');
     console.error('Run with --help for usage information');
     process.exit(1);
   }
-  
+
   // Load configuration
   const config = loadConfig(options.configFile);
-  
+
   // Merge CLI options with config
   if (options.excludeChecks.length > 0) {
     config.excludeChecks = [...(config.excludeChecks || []), ...options.excludeChecks];
@@ -409,23 +417,23 @@ async function main() {
   if (options.includeChecks) {
     config.includeChecks = options.includeChecks;
   }
-  
+
   // Expand file paths
   const files = expandFilePaths(options.files);
-  
+
   if (files.length === 0) {
     console.error('Error: No JSON files found');
     process.exit(1);
   }
-  
+
   if (options.verbose) {
     console.log(`Linting ${files.length} file(s)...`);
   }
-  
+
   // Create linter and run
   const linter = new SchemaLinter(config);
   const results = await linter.lintFiles(files);
-  
+
   // Format and output results
   let output;
   switch (options.format) {
@@ -439,9 +447,9 @@ async function main() {
     default:
       output = formatStylish(results, options);
   }
-  
+
   console.log(output);
-  
+
   // Exit with error code if there are errors
   const hasErrors = results.some(r => r.hasErrors());
   process.exit(hasErrors ? 1 : 0);


### PR DESCRIPTION
the linter checks are now autodiscovered
and are applied to the CT

they may be excpluded via 
```yml
jobs:
  lint-schemas:
      matrix:
        schema_version: ${{ fromJSON(needs.discover-schema.outputs.versions) }}
        linter_test: ${{ fromJSON(needs.discover-linter.outputs.tests) }}
      # you could exclude some combinations via matrix.exclude
      # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrixexclude
        exclude:
          - schema_version: '2.0'
            linter_test: 'no-uppercase-rfc'
```