### PR TITLE
linter: mixin fix

### DIFF
--- a/schema/2.0/model/cyclonedx-behavior-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-behavior-2.0.schema.json
@@ -230,7 +230,6 @@
                   "properties": {
                     "ordinal": true
                   },
-                  "additionalProperties": true,
                   "$comment": "This is a mixin - this is just a minimal constraint",
                   "type": "object"
                 }

--- a/schema/2.0/model/cyclonedx-common-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-common-2.0.schema.json
@@ -584,7 +584,6 @@
       "type": "object",
       "title": "Extensible Properties",
       "$comment": "This is a mixin. It intentionally does NOT restrict additional/unevaluated properties itself; schemas composing it via `allOf` are expected to close themselves with `unevaluatedProperties: false` so that both their own defined properties and these patternProperties remain usable.",
-      "additionalProperties": true,
       "patternProperties": {
         "^ext:[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}:.+$": {
           "description": "CycloneDX supports a structured and namespace-aware mechanism for extensibility through the use of extensible properties. This mechanism enables organizations, ecosystems, and tool vendors to safely introduce custom properties without conflicting with the core schema or other extensions.\n\nExtensible properties are defined as a JSON object whose keys must conform to a strict pattern that resembles a reverse domain name structure, prefixed with ext:. This pattern provides a namespacing convention that aligns with well-established practices in other structured formats (e.g., XML namespaces).\n\nValues that are objects must declare the schema they conform to via `$schema`. This requirement applies recursively to objects contained in arrays, at any nesting depth.",
@@ -606,8 +605,7 @@
               "type": "string",
               "format": "uri"
             }
-          },
-          "additionalProperties": true
+          }
         },
         "propertyValue": {
           "title": "Extensible Property Value",
@@ -649,8 +647,7 @@
         "externalReferences": {
           "$ref": "#/$defs/externalReferences"
         }
-      },
-      "additionalProperties": true
+      }
     },
     "timestamp": {
       "type": "string",

--- a/schema/2.0/model/cyclonedx-evidence-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-evidence-2.0.schema.json
@@ -274,7 +274,6 @@
         { "$ref": "#/$defs/analysisMethod" },
         {
           "type": "object",
-          "additionalProperties": true,
           "$comment": "This is a mixin - it is controlled by the other `allOf`",
           "properties": {
             "technique": {
@@ -304,7 +303,6 @@
         { "$ref": "#/$defs/analysisMethod" },
         {
           "type": "object",
-          "additionalProperties": true,
           "$comment": "This is a mixin - it is controlled by the other `allOf`",
           "properties": {
             "technique": {

--- a/schema/2.0/model/cyclonedx-vulnerability-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-vulnerability-2.0.schema.json
@@ -674,7 +674,6 @@
                       "not": { "enum": [ "not-detected", "inconclusive" ] }
                     }
                   },
-                  "additionalProperties": true,
                   "$comment": "This is a mixin - this is just a minimal constraint",
                   "type": "object"
                 }

--- a/tools/src/main/js/linter/README.md
+++ b/tools/src/main/js/linter/README.md
@@ -65,8 +65,7 @@ node cli.js schema.json
 | `duplicate-definitions` | Definitions must be reused via `$ref`, not duplicated |
 | `no-todos` | No TODO markers in the schema |
 | `ref-best-practice` | `$ref` usage must follow JSON Schema best practice: string value, no absolute references, same-file references start with `#`, and no non-documentational siblings alongside `$ref` |
-| `object-strictness` | Structural object schemas must set exactly one of `additionalProperties`/`unevaluatedProperties`: `true` for mixins (marked by `this is a mixin` in `description` or `$comment`, configurable via `mixinMarker`), `false` otherwise; purely documentational objects are skipped |
-
+| `object-strictness` | Structural object schemas must declare their strictness via at most one of `additionalProperties`/`unevaluatedProperties` — never both. Non-mixins must set it to `false`. Mixins (marked by `this is a mixin` in `description` or `$comment`, configurable via `mixinMarker`) must set it to `true` or may omit it entirely; purely documentational objects are skipped |
 ## Configuration
 
 Create `.cdxlintrc.json` in your project root:

--- a/tools/src/main/js/linter/checks/object-strictness.check.js
+++ b/tools/src/main/js/linter/checks/object-strictness.check.js
@@ -6,13 +6,15 @@
  * - Object schemas that carry nothing but documentational/annotation keywords
  *   (title, description, examples, ...) are skipped - there is nothing structural
  *   to be strict about.
- * - Exactly one of `additionalProperties`/`unevaluatedProperties`
- *   must be present - never both, never neither.
  * - A schema is a "mixin" if its `description` or `$comment` contains the
  *   mixin marker string (case-insensitive; default: "this is a mixin",
  *   configurable via `mixinMarker`). Mixins are meant to be composed via
- *   `allOf`, so they must be explicitly open: the present keyword must be `true`.
- * - Non-mixins must be closed: the present keyword must be `false`.
+ *   `allOf`, so they must be explicitly open: if a strictness keyword is
+ *   present, it must be `true`; the keyword may also be omitted entirely
+ *   (JSON Schema objects are implicitly open).
+ * - Non-mixins must be closed: exactly one of
+ *   `additionalProperties`/`unevaluatedProperties` must be present - never
+ *   both, never neither - and it must be `false`.
  *
  * @license Apache-2.0
  */
@@ -41,7 +43,7 @@ const NON_STRUCTURAL_KEYWORDS = Object.freeze(new Set([
   '$id', '$anchor', '$schema', // identifiers
   '$defs', 'definitions', // defs
   'enum', 'const', 'default', // values
-  '$comment', 'title', 'description', 'examples', 'default', 'readOnly', 'writeOnly', 'meta:enum', // documentational/annotations
+  '$comment', 'title', 'description', 'examples', 'readOnly', 'writeOnly', 'meta:enum', // documentational/annotations
   ...STRICTNESS_KEYWORDS, // the strictness declaration itself doesn't count as structure
 ]));
 
@@ -85,7 +87,7 @@ class ObjectStrictnessCheck extends LintCheck {
     super(
       'object-strictness',
       'Object Strictness',
-      'Validates that structural object schemas set exactly one of additionalProperties/unevaluatedProperties: true for mixins, false otherwise.',
+      'Validates that structural object schemas set exactly one of additionalProperties/unevaluatedProperties: false for non-mixins; mixins may set it to true or omit it.',
       Severity.ERROR
     );
   }
@@ -116,15 +118,19 @@ class ObjectStrictnessCheck extends LintCheck {
         return;
       }
 
+      const mixin = isMixin(node);
       const present = STRICTNESS_KEYWORDS.filter(kw => kw in node);
 
       if (present.length === 0) {
-        issues.push(this.createIssue(
-          'Object schema must declare its strictness: ' +
-          'set exactly one of "additionalProperties"/"unevaluatedProperties".',
-          path,
-          { actual: 'neither present', expected: 'exactly one present' }
-        ));
+        if (!mixin) {
+          issues.push(this.createIssue(
+            'Object schema must declare its strictness: ' +
+            'set exactly one of "additionalProperties"/"unevaluatedProperties".',
+            path,
+            { actual: 'neither present', expected: 'exactly one present' }
+          ));
+        }
+        // mixins may omit the strictness keyword entirely - they are implicitly open
         return;
       }
 
@@ -139,16 +145,15 @@ class ObjectStrictnessCheck extends LintCheck {
       }
 
       const keyword = present[0];
-      const expected = isMixin(node)
 
-      if (node[keyword] !== expected) {
+      if (node[keyword] !== mixin) {
         issues.push(this.createIssue(
-          expected
-            ? `Mixin object schema must set ${keyword} to true.`
+          mixin
+            ? `Mixin object schema must set ${keyword} to true (or omit it entirely).`
             : `Object schema must set ${keyword} to false, ` +
             `or be marked as a mixin by adding "${mixinMarker}" to its description or $comment.`,
           `${path}.${keyword}`,
-          { actual: JSON.stringify(node[keyword]), expected: String(expected) }
+          { actual: JSON.stringify(node[keyword]), expected: String(mixin) }
         ));
       }
     });


### PR DESCRIPTION
- reverts wrong schema changes of https://github.com/CycloneDX/specification/pull/1069
- adjusts the linter accordingly