### PR TITLE
revisit linter check for schema ref best practice

### DIFF
--- a/schema/2.0/model/cyclonedx-ai-modelcard-2.0.schema.json
+++ b/schema/2.0/model/cyclonedx-ai-modelcard-2.0.schema.json
@@ -83,7 +83,6 @@
                       "ref": {
                         "$ref": "cyclonedx-common-2.0.schema.json#/$defs/elementLink",
                         "title": "Reference",
-                        "type": "string",
                         "description": "References a data component by the components bom-ref attribute"
                       }
                     }

--- a/tools/src/main/js/linter/README.md
+++ b/tools/src/main/js/linter/README.md
@@ -46,6 +46,7 @@ node cli.js schema.json
 | `schema-draft` | Validates `$schema` is `https://json-schema.org/draft/2020-12/schema` |
 | `schema-id-pattern` | Validates `$id` matches CycloneDX URL pattern |
 | `schema-id-filepath` | Validates `$id` property matches the expected file path |
+| `schema-ref-best-practice` | `$ref` usage must follow JSON Schema best practice: is string value, not absolute references, same-file references start with `#`, and no non-documentational siblings alongside `$ref`exist |
 | `schema-comment` | Validates `$comment` contains required OWASP/Ecma standard notice |
 | `additional-properties-consistency` | TODO |
 | `model-property-order` | Validates model schemas have properties in order: `$schema`, `$id`, `type`, `title`, `$comment`, `$defs` |
@@ -64,7 +65,6 @@ node cli.js schema.json
 | `duplicate-content` | Titles and descriptions must be unique within a schema |
 | `duplicate-definitions` | Definitions must be reused via `$ref`, not duplicated |
 | `no-todos` | No TODO markers in the schema |
-| `ref-best-practice` | `$ref` usage must follow JSON Schema best practice: string value, no absolute references, same-file references start with `#`, and no non-documentational siblings alongside `$ref` |
 | `object-strictness` | Structural object schemas must declare their strictness via at most one of `additionalProperties`/`unevaluatedProperties` — never both. Non-mixins must set it to `false`. Mixins (marked by `this is a mixin` in `description` or `$comment`, configurable via `mixinMarker`) must set it to `true` or may omit it entirely; purely documentational objects are skipped |
 | `no-deprecated` | No deprecated schemas (`deprecated: true`); optionally (default: on) no deprecation marker (configurable regex) in docs keys (configurable, default `$comment`/`title`/`description`) or `meta:enum` docs |
 | `cdx2-ref-type-usage` | CycloneDX-specific: `bom-ref` properties must `$ref` the shared `refType` definition; nothing else may reference `refType` (except `refLinkType`, which inherits from it) |

--- a/tools/src/main/js/linter/README.md
+++ b/tools/src/main/js/linter/README.md
@@ -46,7 +46,7 @@ node cli.js schema.json
 | `schema-draft` | Validates `$schema` is `https://json-schema.org/draft/2020-12/schema` |
 | `schema-id-pattern` | Validates `$id` matches CycloneDX URL pattern |
 | `schema-id-filepath` | Validates `$id` property matches the expected file path |
-| `schema-ref-best-practice` | `$ref` usage must follow JSON Schema best practice: is string value, not absolute references, same-file references start with `#`, and no non-documentational siblings alongside `$ref`exist |
+| `schema-ref-best-practice` | `$ref` usage must follow JSON Schema best practice: is string value, not absolute references, same-file references start with `#`, and no non-annotation siblings alongside `$ref`exist |
 | `schema-comment` | Validates `$comment` contains required OWASP/Ecma standard notice |
 | `additional-properties-consistency` | TODO |
 | `model-property-order` | Validates model schemas have properties in order: `$schema`, `$id`, `type`, `title`, `$comment`, `$defs` |

--- a/tools/src/main/js/linter/checks/index.js
+++ b/tools/src/main/js/linter/checks/index.js
@@ -37,9 +37,9 @@ export async function loadAllChecks() {
 // Export individual check modules for direct access if needed
 export * from './schema-id-pattern.check.js';
 export * from './schema-id-filepath.check.js';
+export * from './schema-ref-best-practice.check.js';
 export * from './schema-comment.check.js';
 export * from './schema-draft.check.js';
-export * from './ref-best-practice.check.js';
 export * from './model-property-order.check.js';
 export * from './model-structure.check.js';
 export * from './formatting-indent.check.js';

--- a/tools/src/main/js/linter/checks/schema-ref-best-practice.check.js
+++ b/tools/src/main/js/linter/checks/schema-ref-best-practice.check.js
@@ -20,8 +20,13 @@ import { LintCheck, registerCheck, Severity, traverseSchema } from '../index.js'
  */
 const REF_ALLOWED_SIBLINGS = Object.freeze(new Set([
   '$ref', // the $ref itself
-  '$comment', 'title', 'description', 'examples', 'default', // documentational
-  /* do NOT add any non-documentationals
+  '$comment', // documentational
+  // annotations - see https://json-schema.org/understanding-json-schema/reference/annotations
+  'title', 'description',
+  'default', 'examples',
+  'readOnly', 'writeOnly',
+  'deprecated',
+  /* do NOT add any non-annotations here
      instead, use:
      { "allOf": { "$ref": ... }, "$id" ..., "$anchor": ... }
      instead of additionalProperties -- { "allOf": { "$ref": ... }, "unevaluatedItems" ... }
@@ -33,7 +38,8 @@ const REF_ALLOWED_SIBLINGS = Object.freeze(new Set([
  */
 const SKIP_KEYS = Object.freeze(new Set([
   'enum', 'const', // values
-  'default', 'examples', 'meta:enum', // documentational
+  'default', 'examples', // annotations
+  'meta:enum', // documentational
 ]));
 
 

--- a/tools/src/main/js/linter/checks/schema-ref-best-practice.check.js
+++ b/tools/src/main/js/linter/checks/schema-ref-best-practice.check.js
@@ -20,11 +20,10 @@ import { LintCheck, registerCheck, Severity, traverseSchema } from '../index.js'
  */
 const REF_ALLOWED_SIBLINGS = Object.freeze(new Set([
   '$ref', // the $ref itself
-  '$comment', 'title', 'description', 'examples', // documentational
+  '$comment', 'title', 'description', 'examples', 'default', // documentational
   /* do NOT add any non-documentationals
      instead, use:
      { "allOf": { "$ref": ... }, "$id" ..., "$anchor": ... }
-     { "allOf": { "$ref": ... }, "default" ... }
      instead of additionalProperties -- { "allOf": { "$ref": ... }, "unevaluatedItems" ... }
    */
 ]));
@@ -33,8 +32,8 @@ const REF_ALLOWED_SIBLINGS = Object.freeze(new Set([
  * Keys whose values aren't schemas - their entire subtrees are pruned
  */
 const SKIP_KEYS = Object.freeze(new Set([
-  'enum', 'const', 'default', // values
-  'examples', 'meta:enum', // documentational
+  'enum', 'const', // values
+  'default', 'examples', 'meta:enum', // documentational
 ]));
 
 
@@ -72,10 +71,10 @@ function makeSameFileTest(schema, filePath) {
 /**
  * Check that validates `$ref` best practice.
  */
-class RefBestPracticeCheck extends LintCheck {
+class SchemaRefBestPracticeCheck extends LintCheck {
   constructor() {
     super(
-      'ref-best-practice',
+      'schema-ref-best-practice',
       '$ref Best Practice',
       'Validates that $ref usage follows JSON Schema best practice.',
       Severity.ERROR
@@ -146,8 +145,8 @@ class RefBestPracticeCheck extends LintCheck {
 }
 
 // Create and register the check
-const check = new RefBestPracticeCheck();
+const check = new SchemaRefBestPracticeCheck();
 registerCheck(check);
 
-export { RefBestPracticeCheck };
+export { SchemaRefBestPracticeCheck };
 export default check;


### PR DESCRIPTION
- renamed schema linter check
- added more allowed annotation - as of https://json-schema.org/understanding-json-schema/reference/annotations
- fixed a bug in a schema