### PR TITLE
chore: linter order checks alhabetically

### DIFF
--- a/tools/src/main/js/linter/README.md
+++ b/tools/src/main/js/linter/README.md
@@ -43,31 +43,29 @@ node cli.js schema.json
 
 | Check | Description |
 |-------|-------------|
-| `schema-draft` | Validates `$schema` is `https://json-schema.org/draft/2020-12/schema` |
-| `schema-id-pattern` | Validates `$id` matches CycloneDX URL pattern |
-| `schema-id-filepath` | Validates `$id` property matches the expected file path |
-| `schema-ref-best-practice` | `$ref` usage must follow JSON Schema best practice: is string value, not absolute references, same-file references start with `#`, and no non-annotation siblings alongside `$ref`exist |
-| `schema-comment` | Validates `$comment` contains required OWASP/Ecma standard notice |
-| `additional-properties-consistency` | TODO |
-| `model-property-order` | Validates model schemas have properties in order: `$schema`, `$id`, `type`, `title`, `$comment`, `$defs` |
-| `model-structure` | Validates model schemas have `type: "null"`, `$defs`, and no `properties` |
-| `formatting-indent` | Validates 2-space indentation, no tabs, no trailing whitespace, LF line endings |
+| `cdx2-reftype-usage` | CycloneDX-specific: `bom-ref` properties must `$ref` the shared `refType` definition; nothing else may reference `refType` (except `refLinkType`, which inherits from it) |
 | `description-full-stop` | Descriptions must end with a full stop |
-| `meta-enum-full-stop` | `meta:enum` values must end with a full stop |
-| `property-name-american-english` | Property names must use American English spelling |
 | `description-oxford-english` | Descriptions must use Oxford English spelling (British with -ize) |
-| `no-uppercase-rfc` | No uppercase RFC 2119 keywords (MUST, SHALL, SHOULD, etc.) |
-| `no-must-word` | Use "shall" instead of "must" per ISO House Style |
-| `title-formatting` | Titles must use sentence case |
-| `enum-value-formatting` | Enum values must be lowercase kebab-case; `meta:enum` must cover all values |
-| `enum-value-no-other` | Enum values must not be literal "other" |
-| `enum-value-other` | Enum values must not be literal "other"; use custom-object style instead |
 | `duplicate-content` | Titles and descriptions must be unique within a schema |
 | `duplicate-definitions` | Definitions must be reused via `$ref`, not duplicated |
-| `no-todos` | No TODO markers in the schema |
-| `object-strictness` | Structural object schemas must declare their strictness via at most one of `additionalProperties`/`unevaluatedProperties` — never both. Non-mixins must set it to `false`. Mixins (marked by `this is a mixin` in `description` or `$comment`, configurable via `mixinMarker`) must set it to `true` or may omit it entirely; purely documentational objects are skipped |
+| `enum-value-formatting` | Enum values must be lowercase kebab-case; `meta:enum` must cover all values |
+| `enum-value-no-other` | Enum values must not be literal "other"; use custom-object style instead |
+| `formatting-indent` | Validates 2-space indentation, no tabs, no trailing whitespace, LF line endings |
+| `meta-enum-full-stop` | `meta:enum` values must end with a full stop |
+| `model-property-order` | Validates model schemas have properties in order: `$schema`, `$id`, `type`, `title`, `$comment`, `$defs` |
+| `model-structure` | Validates model schemas have `type: "null"`, `$defs`, and no `properties` |
 | `no-deprecated` | No deprecated schemas (`deprecated: true`); optionally (default: on) no deprecation marker (configurable regex) in docs keys (configurable, default `$comment`/`title`/`description`) or `meta:enum` docs |
-| `cdx2-ref-type-usage` | CycloneDX-specific: `bom-ref` properties must `$ref` the shared `refType` definition; nothing else may reference `refType` (except `refLinkType`, which inherits from it) |
+| `no-must-word` | Use "shall" instead of "must" per ISO House Style |
+| `no-todos` | No TODO markers in the schema |
+| `no-uppercase-rfc` | No uppercase RFC 2119 keywords (MUST, SHALL, SHOULD, etc.) |
+| `object-strictness` | Structural object schemas must declare their strictness via at most one of `additionalProperties`/`unevaluatedProperties` — never both. Non-mixins must set it to `false`. Mixins (marked by `this is a mixin` in `description` or `$comment`, configurable via `mixinMarker`) must set it to `true` or may omit it entirely; purely documentational objects are skipped |
+| `property-name-american-english` | Property names must use American English spelling |
+| `schema-comment` | Validates `$comment` contains required OWASP/Ecma standard notice |
+| `schema-draft` | Validates `$schema` is `https://json-schema.org/draft/2020-12/schema` |
+| `schema-id-filepath` | Validates `$id` property matches the expected file path |
+| `schema-id-pattern` | Validates `$id` matches CycloneDX URL pattern |
+| `schema-ref-best-practice` | `$ref` usage must follow JSON Schema best practice: is string value, not absolute references, same-file references start with `#`, and no non-annotation siblings alongside `$ref`exist |
+| `title-formatting` | Titles must use sentence case |
 
 ## Configuration
 

--- a/tools/src/main/js/linter/checks/cdx2-reftype-usage.check.js
+++ b/tools/src/main/js/linter/checks/cdx2-reftype-usage.check.js
@@ -91,9 +91,9 @@ function relativeUrl(from, to) {
 class RefTypeUsageCheck extends LintCheck {
   constructor() {
     super(
-      'cdx2-ref-type-usage',
+      'cdx2-reftype-usage',
       'RefType Usage',
-      'CycloneDX2-specific: validates that `bom-ref` properties `$ref` the shared refType definition, and that refType is not referenced anywhere else (except refLinkType).',
+      'CycloneDX2-specific: validates that `bom-ref` properties `$ref` the shared `refType` definition, and that `refType` is not referenced anywhere else (except `refLinkType`).',
       Severity.ERROR
     );
   }

--- a/tools/src/main/js/linter/checks/cdx2-reftype-usage.check.js
+++ b/tools/src/main/js/linter/checks/cdx2-reftype-usage.check.js
@@ -86,9 +86,9 @@ function relativeUrl(from, to) {
 }
 
 /**
- * Check that `bom-ref` properties `$ref` refType — and nothing else does.
+ * CycloneDX2-specific: Check that `bom-ref` properties ref the `refType` — and nothing else does.
  */
-class RefTypeUsageCheck extends LintCheck {
+class Cdx2RefTypeUsageCheck extends LintCheck {
   constructor() {
     super(
       'cdx2-reftype-usage',
@@ -250,8 +250,8 @@ class RefTypeUsageCheck extends LintCheck {
 }
 
 // Create and register the check
-const check = new RefTypeUsageCheck();
+const check = new Cdx2RefTypeUsageCheck();
 registerCheck(check);
 
-export { RefTypeUsageCheck };
+export { Cdx2RefTypeUsageCheck };
 export default check;

--- a/tools/src/main/js/linter/checks/enum-value-no-other.check.js
+++ b/tools/src/main/js/linter/checks/enum-value-no-other.check.js
@@ -18,7 +18,7 @@ class EnumValueNoOtherCheck extends LintCheck {
     super(
       'enum-value-no-other',
       'Enum Value No Other',
-      'Validates that enum values are not literal "other".',
+      'Validates that enum values are not literal "other"; use custom-object style instead',
       Severity.ERROR
     );
   }

--- a/tools/src/main/js/linter/checks/index.js
+++ b/tools/src/main/js/linter/checks/index.js
@@ -7,9 +7,9 @@
  * @license Apache-2.0
  */
 
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { readdirSync } from 'fs';
+import {readdirSync} from 'fs';
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -34,27 +34,27 @@ export async function loadAllChecks() {
   await Promise.all(loadPromises);
 }
 
-// Export individual check modules for direct access if needed
-export * from './schema-id-pattern.check.js';
-export * from './schema-id-filepath.check.js';
-export * from './schema-ref-best-practice.check.js';
-export * from './schema-comment.check.js';
-export * from './schema-draft.check.js';
-export * from './model-property-order.check.js';
-export * from './model-structure.check.js';
-export * from './formatting-indent.check.js';
+// Export individual check modules for registration and direct access if needed
+export * from './cdx2-reftype-usage.check.js';
 export * from './description-full-stop.check.js';
-export * from './meta-enum-full-stop.check.js';
-export * from './property-name-american-english.check.js';
 export * from './description-oxford-english.check.js';
-export * from './no-uppercase-rfc.check.js';
-export * from './no-must-word.check.js';
-export * from './title-formatting.check.js';
-export * from './enum-value-formatting.check.js';
-export * from './enum-value-no-other.check.js';
 export * from './duplicate-content.check.js';
 export * from './duplicate-definitions.check.js';
-export * from './no-todos.check.js';
-export * from './object-strictness.check.js';
+export * from './enum-value-formatting.check.js';
+export * from './enum-value-no-other.check.js';
+export * from './formatting-indent.check.js';
+export * from './meta-enum-full-stop.check.js';
+export * from './model-property-order.check.js';
+export * from './model-structure.check.js';
 export * from './no-deprecated.check.js';
-export * from './cdx2-refType-usage.check.js';
+export * from './no-must-word.check.js';
+export * from './no-todos.check.js';
+export * from './no-uppercase-rfc.check.js';
+export * from './object-strictness.check.js';
+export * from './property-name-american-english.check.js';
+export * from './schema-comment.check.js';
+export * from './schema-draft.check.js';
+export * from './schema-id-filepath.check.js';
+export * from './schema-id-pattern.check.js';
+export * from './schema-ref-best-practice.check.js';
+export * from './title-formatting.check.js';

--- a/tools/src/main/js/linter/checks/index.js
+++ b/tools/src/main/js/linter/checks/index.js
@@ -7,9 +7,9 @@
  * @license Apache-2.0
  */
 
-import {readdirSync} from 'fs';
-import {dirname, join} from 'path';
-import {fileURLToPath} from 'url';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { readdirSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
- orderred the checks
- added docs when missing
- renamed `cdx2-ref-type-usage` --> `cdx2-reftype-usage`