### PR TITLE
tests: lint non-core schemas

### DIFF
--- a/.config/behavior-taxonomy.cdxlintrc.json
+++ b/.config/behavior-taxonomy.cdxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/behavior-taxonomy.schema.json`",
+  "$comment": "This ia a cdxlinter config for file `../schema/behavior-taxonomy.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2

--- a/.config/behavior-taxonomy.cdxlintrc.json
+++ b/.config/behavior-taxonomy.cdxlintrc.json
@@ -1,0 +1,25 @@
+{
+  "NOTE": "This ia a cdxlinter config for file `../schema/behavior-taxonomy.schema.json`",
+  "checks": {
+    "formatting-indent": {
+      "spaces": 2
+    },
+    "schema-draft": {
+      "requiredSchema": "https://json-schema.org/draft/2020-12/schema"
+    },
+    "schema-id-filepath": {
+      "pattern": "^https://cyclonedx\\.org(/schema/[^/]+\\.schema\\.json)$"
+    },
+    "schema-id-pattern": {
+      "pattern": "^https://cyclonedx\\.org/schema/[^/]+\\.schema\\.json$"
+    }
+  },
+  "excludeChecks": [
+    "cdx2-reftype-usage",
+    "description-oxford-english",
+    "enum-value-formatting",
+    "model-structure",
+    "model-property-order",
+    "property-name-american-english"
+  ]
+}

--- a/.config/cryptography-defs.cdxlintrc.json
+++ b/.config/cryptography-defs.cdxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/cryptography-defs.schema.json`",
+  "$comment": "This ia a cdxlinter config for file `../schema/cryptography-defs.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2

--- a/.config/cryptography-defs.cdxlintrc.json
+++ b/.config/cryptography-defs.cdxlintrc.json
@@ -1,14 +1,14 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/jsf-0.82.schema.json`",
+  "NOTE": "This ia a cdxlinter config for file `../schema/cryptography-defs.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2
     },
     "property-name-american-english": {
-      "customTerms": ["crv", "kty"]
+      "customTerms": ["enum"]
     },
     "schema-comment": {
-      "requiredCommentPattern": "JSON Signature Format schema is published under the terms of the Apache License 2\\.0\\."
+      "requiredCommentPattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
     },
     "schema-draft": {
       "requiredSchema": "http://json-schema.org/draft-07/schema#"
@@ -24,8 +24,9 @@
     "cdx2-reftype-usage",
     "description-oxford-english",
     "duplicate-content",
+    "enum-value-formatting",
+    "enum-value-no-other",
     "model-structure",
-    "model-property-order",
-    "no-must-word"
+    "model-property-order"
   ]
 }

--- a/.config/jsf-0.82.cdxlintrc.json
+++ b/.config/jsf-0.82.cdxlintrc.json
@@ -1,11 +1,14 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/spdx.schema.json`",
+  "NOTE": "This ia a cdxlinter config for file `../schema/jsf-0.82.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2
     },
+    "property-name-american-english": {
+      "customTerms": ["crv", "kty"]
+    },
     "schema-comment": {
-      "requiredCommentPattern": "^v(\\d+\\.\\d+)\\-(.+)$"
+      "requiredCommentPattern": "JSON Signature Format schema is published under the terms of the Apache License 2\\.0\\."
     },
     "schema-draft": {
       "requiredSchema": "http://json-schema.org/draft-07/schema#"
@@ -21,12 +24,9 @@
     "cdx2-reftype-usage",
     "description-oxford-english",
     "duplicate-content",
-    "enum-value-formatting",
     "enum-value-no-other",
-    "meta-enum-full-stop",
     "model-structure",
     "model-property-order",
-    "no-must-word",
-    "property-name-american-english"
+    "no-must-word"
   ]
 }

--- a/.config/jsf-0.82.cdxlintrc.json
+++ b/.config/jsf-0.82.cdxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/jsf-0.82.schema.json`",
+  "$comment": "This ia a cdxlinter config for file `../schema/jsf-0.82.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -1,0 +1,20 @@
+{
+  "checks": {
+    "schema-id-filepath": {
+      "pattern": "^http://cyclonedx\\.org(/schema/.+\\.schema\\.json)$"
+    },
+    "schema-id-pattern": {
+      "pattern": "^http://cyclonedx\\.org/schema/.*\\.schema\\.json$"
+    },
+    "schema-draft": {
+      "requiredSchema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  "excludeChecks": [
+    "enum-value-formatting",
+    "meta-enum-full-stop",
+    "description-oxford-english",
+    "property-name-american-english",
+    "schema-comment"
+  ]
+}

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -1,16 +1,19 @@
 {
   "checks": {
+    "formatting-indent": {
+      "spaces": 2
+    },
+    "schema-comment": {
+      "requiredCommentPattern": "^v\\d+\\.\\d+\\-"
+    },
+    "schema-draft": {
+      "requiredSchema": "http://json-schema.org/draft-07/schema#"
+    },
     "schema-id-filepath": {
       "pattern": "^http://cyclonedx\\.org(/schema/[^/]+\\.schema\\.json)$"
     },
     "schema-id-pattern": {
       "pattern": "^http://cyclonedx\\.org/schema/[^/]+\\.schema\\.json$"
-    },
-    "schema-draft": {
-      "requiredSchema": "http://json-schema.org/draft-07/schema#"
-    },
-    "schema-comment": {
-      "requiredComment": "/^v\\d.*/i"
     }
   },
   "excludeChecks": [

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -4,7 +4,7 @@
       "spaces": 2
     },
     "schema-comment": {
-      "requiredCommentPattern": "^v\\d+\\.\\d+\\-.+$"
+      "requiredCommentPattern": "^v(\\d+\\.\\d+)\\-(.+)$"
     },
     "schema-draft": {
       "requiredSchema": "http://json-schema.org/draft-07/schema#"

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -1,20 +1,26 @@
 {
   "checks": {
     "schema-id-filepath": {
-      "pattern": "^http://cyclonedx\\.org(/schema/.+\\.schema\\.json)$"
+      "pattern": "^http://cyclonedx\\.org(/schema/[^/]+\\.schema\\.json)$"
     },
     "schema-id-pattern": {
-      "pattern": "^http://cyclonedx\\.org/schema/.*\\.schema\\.json$"
+      "pattern": "^http://cyclonedx\\.org/schema/[^/]+\\.schema\\.json$"
     },
     "schema-draft": {
       "requiredSchema": "http://json-schema.org/draft-07/schema#"
+    },
+    "schema-comment": {
+      "requiredComment": "/^v\\d.*/i"
     }
   },
   "excludeChecks": [
-    "enum-value-formatting",
-    "meta-enum-full-stop",
+    "cdx2-reftype-usage",
     "description-oxford-english",
-    "property-name-american-english",
-    "schema-comment"
+    "enum-value-formatting",
+    "enum-value-no-other",
+    "meta-enum-full-stop",
+    "model-structure",
+    "model-property-order",
+    "property-name-american-english"
   ]
 }

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -4,7 +4,7 @@
       "spaces": 2
     },
     "schema-comment": {
-      "requiredCommentPattern": "^v\\d+\\.\\d+\\-"
+      "requiredCommentPattern": "^v\\d+\\.\\d+\\-.+$"
     },
     "schema-draft": {
       "requiredSchema": "http://json-schema.org/draft-07/schema#"

--- a/.config/spdx.cdxlintrc.json
+++ b/.config/spdx.cdxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "NOTE": "This ia a cdxlinter config for file `../schema/spdx.schema.json`",
+  "$comment": "This ia a cdxlinter config for file `../schema/spdx.schema.json`",
   "checks": {
     "formatting-indent": {
       "spaces": 2

--- a/.github/workflows/lint_external_schemas.yml
+++ b/.github/workflows/lint_external_schemas.yml
@@ -1,0 +1,75 @@
+name: CT ExternalSchemas Lint
+
+on:
+  push:
+    branches: ['master', 'main']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
+env:
+  NODE_VERSION: '24.x'
+
+jobs:
+  lint-externals:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        schema: # path relative to `schema` dir, without suffix `.schema.json`
+          - 'behavior-taxonomy'
+          - 'cryptography-defs'
+          - 'jsf-0.82'
+          - 'spdx'
+    name: lint ${{ matrix.schema }}
+    env:
+      SCHEMA_FILE: schema/${{ matrix.schema }}.schema.json
+      CONFIG_FILE: .config/${{ matrix.schema }}.cdxlintrc.json
+      REPORT_FILE: tools/src/main/js/linter/reports/${{ matrix.schema }}.json
+    steps:
+      - name: Checkout repository
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+      - name: Install linter
+        working-directory: tools/src/main/js/linter
+        run: npm install
+      - name: Lint schemas
+        run: |
+          set -eu
+          mkdir -p "$(dirname "$REPORT_FILE")"
+          # only run checks not carried over from source files
+          node tools/src/main/js/linter/cli.js \
+            --format json \
+            --config "$CONFIG_FILE" \
+            "$SCHEMA_FILE" \
+            > "$REPORT_FILE"
+      - name: Make report relative
+        if: ${{ !cancelled() }}
+        run: sed -i "s|${GITHUB_WORKSPACE}/||g" "$REPORT_FILE"
+      - name: Print report
+        if: '!cancelled()'
+        run: cat "$REPORT_FILE"
+      - name: Artifact report
+        if: ${{ !cancelled() }}
+        # https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: report_${{ matrix.schema_version }}-bundled
+          path: ${{ env.REPORT_FILE }}
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/lint_non-core_schemas.yml
+++ b/.github/workflows/lint_non-core_schemas.yml
@@ -1,4 +1,4 @@
-name: CT ExternalSchemas Lint
+name: CT Non-Core Schemas Lint
 
 on:
   push:

--- a/.github/workflows/lint_non-core_schemas.yml
+++ b/.github/workflows/lint_non-core_schemas.yml
@@ -47,7 +47,7 @@ jobs:
           package-manager-cache: false
       - name: Install linter
         working-directory: tools/src/main/js/linter
-        run: npm install
+        run: npm ci
       - name: Lint schemas
         run: |
           set -eu
@@ -69,7 +69,7 @@ jobs:
         # https://github.com/actions/upload-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: report_${{ matrix.schema_version }}-bundled
+          name: report_${{ matrix.schema }}
           path: ${{ env.REPORT_FILE }}
           if-no-files-found: error
           retention-days: 1

--- a/schema/jsf-0.82.schema.json
+++ b/schema/jsf-0.82.schema.json
@@ -6,10 +6,10 @@
   "$comment" : "JSON Signature Format schema is published under the terms of the Apache License 2.0. JSF was developed by Anders Rundgren (anders.rundgren.net@gmail.com) as a part of the OpenKeyStore project. This schema supports the entirely of the JSF standard excluding 'extensions'.",
   "definitions": {
     "signature": {
-      "type": "object",
       "title": "Signature",
       "oneOf": [
         {
+          "type": "object",
           "additionalProperties": false,
           "properties": {
             "signers": {
@@ -21,6 +21,7 @@
           }
         },
         {
+          "type": "object",
           "additionalProperties": false,
           "properties": {
             "chain": {
@@ -124,6 +125,7 @@
     "publicKey": {
       "title": "Public key",
       "description": "Optional. Public key object.",
+      "$comment": "This is a mixin - additional properties may be allowed, see the constraints on `kty`.",
       "type": "object",
       "required": [
         "kty"


### PR DESCRIPTION
- added a CI matrix to lint known non-core schemas
- configs are in `//.config` folder