### PR TITLE
chore: linter improv: config & comment-ckeck

### DIFF
--- a/tools/src/main/js/linter/checks/schema-comment.check.js
+++ b/tools/src/main/js/linter/checks/schema-comment.check.js
@@ -12,7 +12,7 @@ import { LintCheck, registerCheck, Severity } from '../index.js';
 /**
  * A regex that matches a regular expression literal on best effort.
  */
-const regexLiteralMatcher = /^\/(?<pattern>.*)\/(?<flags>[dgimsuvy]*)$/;
+const RegexLiteralMatcher = /^\/(?<pattern>.*)\/(?<flags>[dgimsuvy]*)$/;
 
 /**
  * Required $comment text
@@ -36,6 +36,7 @@ class SchemaCommentCheck extends LintCheck {
     const issues = [];
 
     const requiredComment = config.requiredComment ?? REQUIRED_COMMENT;
+    const requiredCommentRE = config.requiredCommentRE;
 
     // Check if $comment exists at root level
     if (!('$comment' in schema)) {
@@ -47,30 +48,38 @@ class SchemaCommentCheck extends LintCheck {
       return issues;
     }
 
-    const requiredCommentREmatch = requiredComment.match(regexLiteralMatcher);
-    if (requiredCommentREmatch) {
-      const requiredCommentRE = new RegExp(
-        requiredCommentREmatch.groups.pattern,
-        requiredCommentREmatch.groups.flags);
+    const comment = schema.$comment;
+    if (!typeof comment !== 'string') {
+      issues.push(this.createIssue(
+        'Schema $comment is not string.',
+        '$.$comment',
+        { expected: 'any string' }
+      ));
+      return issues;
+    }
+
+    if (typeof requiredCommentRE === 'string') {
+      const {pattern, flags} = requiredCommentRE.match(RegexLiteralMatcher).groups;
+      const requiredCommentRegEep = new RegExp(pattern, flags);
       // Check if $comment matches required pattern
-      if (!requiredCommentRE.test(schema.$comment)) {
+      if (!requiredCommentRegEep.test(comment)) {
         issues.push(this.createIssue(
           '$comment does not match the required standard notice.',
           '$.$comment',
           {
-            actual: schema.$comment,
-            expected: `matches ${requiredCommentRE.toString()}`
+            actual: comment,
+            expected: `matches ${requiredCommentRegEep.toString()}`
           }
         ));
       }
     }
     // Check if $comment exactly matches required value
-    else if (schema.$comment !== requiredComment) {
+    else if (comment !== requiredComment) {
       issues.push(this.createIssue(
         '$comment does not match the required standard notice.',
         '$.$comment',
         {
-          actual: schema.$comment,
+          actual: comment,
           expected: requiredComment
         }
       ));

--- a/tools/src/main/js/linter/checks/schema-comment.check.js
+++ b/tools/src/main/js/linter/checks/schema-comment.check.js
@@ -10,11 +10,6 @@
 import { LintCheck, registerCheck, Severity } from '../index.js';
 
 /**
- * A regex that matches a regular expression literal on best effort.
- */
-const RegexLiteralMatcher = /^\/(?<pattern>.*)\/(?<flags>[dgimsuvy]*)$/;
-
-/**
  * Required $comment text
  */
 const REQUIRED_COMMENT = 'OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.';
@@ -36,7 +31,7 @@ class SchemaCommentCheck extends LintCheck {
     const issues = [];
 
     const requiredComment = config.requiredComment ?? REQUIRED_COMMENT;
-    const requiredCommentRE = config.requiredCommentRE;
+    const requiredCommentPattern = config.requiredCommentPattern;
 
     // Check if $comment exists at root level
     if (!('$comment' in schema)) {
@@ -58,17 +53,16 @@ class SchemaCommentCheck extends LintCheck {
       return issues;
     }
 
-    if (typeof requiredCommentRE === 'string') {
-      const {pattern, flags} = requiredCommentRE.match(RegexLiteralMatcher).groups;
-      const requiredCommentRegEep = new RegExp(pattern, flags);
+    if (typeof requiredCommentPattern === 'string') {
+      const requiredCommentRE = new RegExp(requiredCommentPattern);
       // Check if $comment matches required pattern
-      if (!requiredCommentRegEep.test(comment)) {
+      if (!requiredCommentRE.test(comment)) {
         issues.push(this.createIssue(
           '$comment does not match the required standard notice.',
           '$.$comment',
           {
             actual: comment,
-            expected: `matches ${requiredCommentRegEep.toString()}`
+            expected: `matches ${requiredCommentRE.toString()}`
           }
         ));
       }

--- a/tools/src/main/js/linter/checks/schema-comment.check.js
+++ b/tools/src/main/js/linter/checks/schema-comment.check.js
@@ -48,7 +48,10 @@ class SchemaCommentCheck extends LintCheck {
       issues.push(this.createIssue(
         'Schema $comment is not string.',
         '$.$comment',
-        { expected: 'any string' }
+        {
+          actual: comment,
+          expected: 'any string'
+        }
       ));
       return issues;
     }
@@ -58,7 +61,7 @@ class SchemaCommentCheck extends LintCheck {
       // Check if $comment matches required pattern
       if (!requiredCommentRE.test(comment)) {
         issues.push(this.createIssue(
-          '$comment does not match the required standard notice.',
+          '$comment does not match the required standard notice pattern.',
           '$.$comment',
           {
             actual: comment,

--- a/tools/src/main/js/linter/checks/schema-comment.check.js
+++ b/tools/src/main/js/linter/checks/schema-comment.check.js
@@ -44,7 +44,7 @@ class SchemaCommentCheck extends LintCheck {
     }
 
     const comment = schema.$comment;
-    if (!typeof comment !== 'string') {
+    if (typeof comment !== 'string') {
       issues.push(this.createIssue(
         'Schema $comment is not string.',
         '$.$comment',

--- a/tools/src/main/js/linter/checks/schema-comment.check.js
+++ b/tools/src/main/js/linter/checks/schema-comment.check.js
@@ -1,13 +1,18 @@
 /**
  * CycloneDX Schema Linter - Schema Comment Check
- * 
+ *
  * Validates that the root $comment property contains the required
  * OWASP CycloneDX standard notice.
- * 
+ *
  * @license Apache-2.0
  */
 
 import { LintCheck, registerCheck, Severity } from '../index.js';
+
+/**
+ * A regex that matches a regular expression literal on best effort.
+ */
+const regexLiteralMatcher = /^\/(?<pattern>.*)\/(?<flags>[dgimsuvy]*)$/;
 
 /**
  * Required $comment text
@@ -29,9 +34,9 @@ class SchemaCommentCheck extends LintCheck {
 
   async run(schema, rawContent, config = {}) {
     const issues = [];
-    
+
     const requiredComment = config.requiredComment ?? REQUIRED_COMMENT;
-    
+
     // Check if $comment exists at root level
     if (!('$comment' in schema)) {
       issues.push(this.createIssue(
@@ -41,9 +46,26 @@ class SchemaCommentCheck extends LintCheck {
       ));
       return issues;
     }
-    
-    // Check if $comment matches required value
-    if (schema.$comment !== requiredComment) {
+
+    const requiredCommentREmatch = requiredComment.match(regexLiteralMatcher);
+    if (requiredCommentREmatch) {
+      const requiredCommentRE = new RegExp(
+        requiredCommentREmatch.groups.pattern,
+        requiredCommentREmatch.groups.flags);
+      // Check if $comment matches required pattern
+      if (!requiredCommentRE.test(schema.$comment)) {
+        issues.push(this.createIssue(
+          '$comment does not match the required standard notice.',
+          '$.$comment',
+          {
+            actual: schema.$comment,
+            expected: `matches ${requiredCommentRE.toString()}`
+          }
+        ));
+      }
+    }
+    // Check if $comment exactly matches required value
+    else if (schema.$comment !== requiredComment) {
       issues.push(this.createIssue(
         '$comment does not match the required standard notice.',
         '$.$comment',
@@ -53,7 +75,7 @@ class SchemaCommentCheck extends LintCheck {
         }
       ));
     }
-    
+
     return issues;
   }
 }

--- a/tools/src/main/js/linter/cli.js
+++ b/tools/src/main/js/linter/cli.js
@@ -110,7 +110,7 @@ Configuration:
   {
     "checks": {
       "schema-id-pattern": {
-        "pattern": "^https://cyclonedx\\\\.org/schema/.*\\\\.schema\\\\.json$"
+        "pattern": "^https://cyclonedx\\\\.org/schema/.+\\\\.schema\\\\.json$"
       },
       "formatting-indent": {
         "spaces": 2
@@ -184,7 +184,11 @@ function loadConfig(configPath) {
     }
   }
 
-  if (configPath && existsSync(configPath)) {
+  if (configPath) {
+    if (!existsSync(configPath)) {
+      console.error(`Missing config file: ${configPath}`);
+      process.exit(1);
+    }
     try {
       return JSON.parse(readFileSync(configPath, 'utf-8'));
     } catch (err) {


### PR DESCRIPTION
- linter check schema-comment supports regular expressions via config `requiredCommentPattern`
- linter throws error if a config file is expected but missing
- fixed a config file example