### PR TITLE
Add EAX to cryptography registry

### DIFF
--- a/schema/cryptography-defs.json
+++ b/schema/cryptography-defs.json
@@ -431,6 +431,16 @@
         {
           "standard": [
             {
+              "name": "ISO/IEC 19772:2020",
+              "url": "https://www.iso.org/standard/81550.html"
+            }
+          ],
+          "pattern": "AES[-(128|192|256)]-EAX[-{tagLength}][-{nonceLength}]",
+          "primitive": "ae"
+        },
+        {
+          "standard": [
+            {
               "name": "RFC7253",
               "url": "https://doi.org/10.17487/RFC7253"
             }


### PR DESCRIPTION
As discussed in #1098, this adds the EAX mode to the cryptography registry.

fixes #1098